### PR TITLE
Changes the name from tembo-cli to tembo

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -28,9 +28,9 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "tembo-cli-lint"
+          prefix-key: "tembo-lint"
           workspaces: |
-            tembo-cli
+            tembo
       - name: Cargo format
         run: cargo +nightly fmt --check
       - name: Clippy
@@ -45,8 +45,8 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "tembo-cli-test"
+          prefix-key: "tembo-test"
           workspaces: |
-            tembo-cli
+            tembo
       - name: Run tests
         run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "tembo-cli"
+name = "tembo"
 version = "0.2.3"
 dependencies = [
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tembo-cli"
+name = "tembo"
 version = "0.2.3"
 edition = "2021"
 authors = ["Tembo.io"]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,7 +2,7 @@ use assert_cmd::prelude::*; // Add methods on commands
 use predicates::prelude::*; // Used for writing assertions
 use std::process::Command; // Run programs
 
-const CARGO_BIN: &str = "tembo-cli";
+const CARGO_BIN: &str = "tembo";
 
 #[test]
 fn help() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
This PR changes the name from tembo-cli to just tembo; the package name and the command used by users.