### PR TITLE
Introduces an empy install command

### DIFF
--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -1,0 +1,14 @@
+use clap::{ArgMatches, Command};
+use std::error::Error;
+
+// Create clap subcommand arguments
+pub fn make_subcommand() -> Command {
+    Command::new("install")
+        .about("Installs a local Tembo flavored version of Postgres")
+        .arg(arg!(-s --stack "A Tembo stack type to install"))
+}
+
+pub fn execute(_args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    println!("coming soon");
+    Ok(())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,1 +1,2 @@
 pub mod init;
+pub mod install;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ fn main() {
     // Check which subcommand the user ran...
     let res = match command.get_matches().subcommand() {
         Some(("init", sub_matches)) => cmd::init::execute(sub_matches),
+        Some(("install", sub_matches)) => cmd::install::execute(sub_matches),
         Some(("completions", sub_matches)) => (|| {
             let shell = sub_matches
                 .get_one::<Shell>("shell")
@@ -53,6 +54,7 @@ fn create_clap_command() -> Command {
              The source code for tembo is available at: https://github.com/tembo-io/tembo-cli",
         )
         .subcommand(cmd::init::make_subcommand())
+        .subcommand(cmd::install::make_subcommand())
         .subcommand(
             Command::new("completions")
                 .about("Generate shell completions for your shell to stdout")

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -24,3 +24,12 @@ fn init() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn install() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin(CARGO_BIN)?;
+    cmd.arg("install");
+    cmd.assert().stdout(predicate::str::contains("coming soon"));
+
+    Ok(())
+}


### PR DESCRIPTION
This PR introduces an empty `install` command. Only argument right now is a placeholder for specifying the stack type to install.

Next, looking into the Docker files defined for the various stacks and including them in this repo for local installation.

@sjmiller609 I was pointed in your direction as far as container definitions.