### PR TITLE
Config read/write toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +233,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,7 +266,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -507,12 +529,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.2",
  "itoa",
  "ryu",
  "serde",
@@ -585,6 +616,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "spinners",
+ "toml",
 ]
 
 [[package]]
@@ -602,6 +634,40 @@ name = "termtree"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
+
+[[package]]
+name = "toml"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -776,3 +842,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ home = "0.5.5"
 spinners = "4.1.0"
 semver = "1.0.18"
 mockall = "0.11.4"
+toml = "0.7.6"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,108 +1,175 @@
+#![allow(dead_code)]
+
 use clap::ArgMatches;
+use serde::Deserialize;
+use serde::Serialize;
+use std::cmp::PartialEq;
 use std::env;
 use std::error::Error;
+use std::fmt;
 use std::fs;
 use std::fs::File;
-use std::fs::OpenOptions;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::PathBuf;
 
 const CONFIG_FILE_NAME: &str = "configuration.toml";
 
-pub struct Config<'a> {
-    pub file_name: &'a str,
-    pub file_path: PathBuf,
+// NOTE: modifying the struct determines what gets persisted in the configuration file
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Config {
+    pub file_name: String,
+    pub file_path: PathBuf, // NOTE: may support additional file paths in the future (ie. for an individual project or having multiple accounts for example)
+    pub stacks: Stacks,
 }
 
-impl<'a> Config<'a> {
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Stacks {
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub installed_extensions: InstalledExtensions,
+    pub enabled_extensions: EnabledExtensions,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct InstalledExtensions {
+    pub name: Option<String>,
+    pub version: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct EnabledExtensions {
+    pub name: Option<String>,
+    pub version: Option<String>,
+}
+
+impl fmt::Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let config_str = toml::to_string(&self).unwrap();
+
+        f.write_str(config_str.as_ref())
+    }
+}
+
+impl Config {
+    // Returns a default Rust object that will be persisted as serialized toml
     pub fn new(args: &ArgMatches) -> Config {
-        Config {
-            file_name: CONFIG_FILE_NAME, // TODO: support passed in args setting the file_name
-            file_path: Self::full_path(args),
+        match Self::read_to_string(args) {
+            Ok(contents) => Self::to_toml(&contents),
+            Err(_) => {
+                let config = Config {
+                    file_name: CONFIG_FILE_NAME.to_string(),
+                    file_path: Self::full_path(args),
+                    stacks: Stacks {
+                        name: None,
+                        version: None,
+                        installed_extensions: InstalledExtensions {
+                            name: None,
+                            version: None,
+                        },
+                        enabled_extensions: EnabledExtensions {
+                            name: None,
+                            version: None,
+                        },
+                    },
+                };
+
+                let _ = Self::init(&config);
+                let _ = Self::write(&config);
+
+                config
+            }
         }
     }
 
-    pub fn create_config_dir(dir_path: &str) -> Result<(), Box<dyn Error>> {
+    // Reads the contents of any existing config file and returns contents as a string
+    pub fn read_to_string(args: &ArgMatches) -> Result<String, Box<dyn Error>> {
+        let file = Self::full_path(args);
+        let mut file = File::open(file)?;
+        let mut contents = String::new();
+
+        file.read_to_string(&mut contents)
+            .expect("Unable to read stack config file");
+
+        Ok(contents)
+    }
+
+    // Returns a Config object serialized to toml from a string
+    pub fn to_toml(str: &str) -> Config {
+        let config: Config = toml::from_str(str).unwrap();
+
+        config
+    }
+
+    // Writes the current Config to the config file, overwriting anything else that was there
+    pub fn write(&self) -> Result<(), Box<dyn Error>> {
+        let file_path = self.file_path.clone();
+
+        let mut file = File::create(file_path)?;
+        let _delete = file.set_len(0); // this deletes all contents from the file
+        let _result = file.write_all(self.to_string().as_bytes());
+
+        Ok(())
+    }
+
+    // Creates the config directory
+    fn create_config_dir(dir_path: &str) -> Result<(), Box<dyn Error>> {
         fs::create_dir_all(dir_path)?;
 
         Ok(())
     }
 
-    pub fn create_config_file(path: &str) -> Result<(), Box<dyn Error>> {
+    // Creates the config file in the config directory
+    fn create_config_file(path: String) -> Result<(), Box<dyn Error>> {
         File::create_new(path)?; // don't overwrite existing file at path
 
         Ok(())
     }
 
-    fn full_path(args: &ArgMatches) -> PathBuf {
-        // if file-path was provided
-        if let Ok(Some(path)) = args.try_get_one::<PathBuf>("file-path") {
-            if path.is_relative() {
-                env::current_dir()
-                    .expect("Unable to determine the current directory")
-                    .join(path)
-            } else {
-                path.to_path_buf()
-            }
-        } else {
-            // if file-path was not provided, use the home directory as a default
-            let home_dir = home::home_dir();
+    // Returns the full path to the config file
+    fn full_path(_args: &ArgMatches) -> PathBuf {
+        // NOTE: only supporting a file in the home directory for now
+        let home_dir = home::home_dir();
 
-            // if home directory can not be determined, use the current directory
-            match home_dir {
-                Some(mut path) => {
-                    path.push(".config");
-                    path.push("tembo");
-                    path.push(CONFIG_FILE_NAME);
+        // if home directory can not be determined, use the current directory
+        match home_dir {
+            Some(mut path) => {
+                path.push(".config");
+                path.push("tembo");
+                path.push(CONFIG_FILE_NAME);
 
-                    path
-                }
-                None => env::current_dir().expect("Unable to determine the current directory"),
+                path
             }
+            None => env::current_dir().expect("Unable to determine the current directory"),
         }
     }
 
-    pub fn init(file_path: PathBuf) -> Result<(), Box<dyn Error>> {
-        let mut full_path = file_path.clone();
+    // Initializes the config file, creating the directories and files as needed
+    fn init(&self) -> Result<(), Box<dyn Error>> {
+        let mut full_path = self.file_path.clone();
         full_path.pop(); // removes any filename and extension
 
         match Config::create_config_dir(&full_path.to_string_lossy()) {
-            Ok(()) => Config::create_config_file(&file_path.to_string_lossy()),
+            Ok(()) => Config::create_config_file(self.file_path.to_string_lossy().into_owned()),
             Err(e) => {
-                println!("Directory can not be created, {}", e);
+                println!("- Directory can not be created, {}", e);
 
                 Err(e)
             }
         }
-    }
-
-    // TODO: add toml parser for proper appending to section
-    pub fn append(file_path: PathBuf, contents: &str) -> Result<(), Box<dyn Error>> {
-        // Open a file with append option
-        let mut data_file = OpenOptions::new()
-            .append(true)
-            .open(file_path)
-            .expect("cannot open file");
-
-        // Write to a file
-        data_file
-            .write_all(contents.as_bytes())
-            .expect("write failed");
-
-        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::config::Config;
     use clap::{Arg, ArgAction, Command};
     use std::env;
+    use std::io::Read;
 
-    #[test]
-    fn full_path_test() {
-        // with a file-path
-        let file_path = "/foo";
+    // NOTE: many of the tests below assume the config file is in place, this is a convenient
+    // helper to create the file if it doesn't already exist
+    fn setup() {
         let matches = Command::new("myapp")
             .arg(
                 Arg::new("file-path")
@@ -110,11 +177,98 @@ mod tests {
                     .action(ArgAction::Set)
                     .required(false),
             )
-            .get_matches_from(vec!["myapp", &file_path]);
+            .get_matches_from(vec!["myapp"]);
 
-        assert_eq!(Config::full_path(&matches).to_str(), Some(file_path));
+        let _config = Config::new(&matches); // calls init and writes the file
+    }
 
-        // without a file-path
+    #[test]
+    fn read_to_string_test() {
+        setup();
+
+        let matches = Command::new("myapp")
+            .arg(
+                Arg::new("file-path")
+                    .value_parser(clap::value_parser!(std::path::PathBuf))
+                    .action(ArgAction::Set)
+                    .required(false),
+            )
+            .get_matches_from(vec!["myapp"]);
+
+        let config = Config::read_to_string(&matches);
+
+        assert_eq!(config.is_ok(), true);
+    }
+
+    #[test]
+    fn to_toml_test() {
+        let matches = Command::new("myapp")
+            .arg(
+                Arg::new("file-path")
+                    .value_parser(clap::value_parser!(std::path::PathBuf))
+                    .action(ArgAction::Set)
+                    .required(false),
+            )
+            .get_matches_from(vec!["myapp"]);
+
+        // defaults
+        let config = Config::new(&matches);
+        let toml = Config::to_toml(&config.to_string());
+
+        assert_eq!(toml.file_name, CONFIG_FILE_NAME);
+        assert_eq!(
+            toml.stacks,
+            Stacks {
+                name: None,
+                version: None,
+                installed_extensions: InstalledExtensions {
+                    name: None,
+                    version: None,
+                },
+                enabled_extensions: EnabledExtensions {
+                    name: None,
+                    version: None,
+                }
+            }
+        );
+
+        // wth stacks
+        let mut config = Config::new(&matches);
+        config.stacks = Stacks {
+            name: Some(String::from("stack_name")),
+            version: Some(String::from("1.1")),
+            installed_extensions: InstalledExtensions {
+                name: Some(String::from("pgmq")),
+                version: Some(String::from("1.0")),
+            },
+            enabled_extensions: EnabledExtensions {
+                name: Some(String::from("pgmq")),
+                version: Some(String::from("1.0")),
+            },
+        };
+
+        let toml = Config::to_toml(&config.to_string());
+
+        assert_eq!(toml.file_name, CONFIG_FILE_NAME);
+        assert_eq!(
+            toml.stacks,
+            Stacks {
+                name: Some(String::from("stack_name")),
+                version: Some(String::from("1.1")),
+                installed_extensions: InstalledExtensions {
+                    name: Some(String::from("pgmq")),
+                    version: Some(String::from("1.0")),
+                },
+                enabled_extensions: EnabledExtensions {
+                    name: Some(String::from("pgmq")),
+                    version: Some(String::from("1.0")),
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn full_path_test() {
         let matches = Command::new("myapp")
             .arg(
                 Arg::new("file-path")
@@ -139,10 +293,10 @@ mod tests {
         path.push("tests");
         path.push(".config");
 
-        let write = Config::create_config_dir(&path.to_string_lossy());
+        let write = Config::create_config_dir(&path.to_string_lossy().into_owned());
         assert_eq!(write.is_ok(), true);
 
-        let overwrite = Config::create_config_file(&path.to_string_lossy());
+        let overwrite = Config::create_config_file(path.to_string_lossy().into_owned());
         assert_eq!(overwrite.is_err(), true);
 
         // clean up
@@ -155,13 +309,41 @@ mod tests {
         path.push("tests");
         path.push("configuration.toml");
 
-        let write = Config::create_config_file(&path.to_string_lossy());
+        let write = Config::create_config_file(path.to_string_lossy().into_owned());
         assert_eq!(write.is_ok(), true);
 
-        let overwrite = Config::create_config_file(&path.to_string_lossy());
+        let overwrite = Config::create_config_file(path.to_string_lossy().into_owned());
         assert_eq!(overwrite.is_err(), true);
 
         // clean up
         let _ = std::fs::remove_file(&*path.to_string_lossy());
+    }
+
+    #[test]
+    fn init_test() {
+        setup();
+        // retrieves the full path, pops off the file_path, creates the directories if needed, and
+        // writes the file
+        let matches = Command::new("myapp")
+            .arg(
+                Arg::new("file-path")
+                    .value_parser(clap::value_parser!(std::path::PathBuf))
+                    .action(ArgAction::Set)
+                    .required(false),
+            )
+            .get_matches_from(vec!["myapp"]);
+
+        let _config = Config::new(&matches); // calls init and writes the file
+        let path = Config::full_path(&matches);
+
+        let file = File::open(path);
+        let mut contents = String::new();
+
+        let _ = file.unwrap().read_to_string(&mut contents);
+
+        assert_eq!(contents, Config::to_toml(&contents).to_string());
+
+        // clean up
+        let _ = std::fs::remove_file(Config::full_path(&matches));
     }
 }

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,81 +1,20 @@
 use crate::cli::config::Config;
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{ArgMatches, Command};
 use std::error::Error;
-use std::path::PathBuf;
 
 // Create clap subcommand arguments
 pub fn make_subcommand() -> Command {
     Command::new("init")
         .about("Initializes a local environment or project; generates configuration")
-        .arg(arg!(-d --dryrun "Provides an input file to the program"))
-        .arg(
-            Arg::new("file-path")
-                .short('f')
-                .long("file-path")
-                .value_name("dir")
-                .value_parser(clap::value_parser!(std::path::PathBuf))
-                .action(ArgAction::Append)
-                .help(
-                    "A path to the directory to add to the configuration \
-                    file to, default is $HOME/.config/tembo",
-                ),
-        )
 }
 
 pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
-    let config: Config = Config::new(args);
-    let dry_run: bool = args.get_flag("dryrun");
-    let file_path: PathBuf = config.file_path;
+    let config = Config::new(args);
 
-    if dry_run {
-        println!(
-            "- config file would be created at: {}",
-            &file_path.to_string_lossy()
-        );
-    } else {
-        println!(
-            "- config file will be created at: {}",
-            &file_path.to_string_lossy()
-        );
-
-        // initialize the required directories and file
-        match Config::init(file_path.clone()) {
-            Ok(_) => {
-                println!("- {} was written", &file_path.to_string_lossy());
-                let _ = Config::append(file_path.clone(), "[configuration]");
-            }
-            Err(e) => eprintln!("- {}; exiting", e),
-        }
-    }
+    println!(
+        "- config file created at: {}",
+        &config.file_path.to_string_lossy()
+    );
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::Path;
-
-    #[test]
-    fn execute_test() {
-        // assert that dry-run doesn't write the file
-        let file_path = "./test/dryrun/test.toml";
-        let path = Path::new(file_path);
-        let m = Command::new("myapp")
-            .arg(
-                Arg::new("dryrun")
-                    .value_parser(clap::value_parser!(bool))
-                    .action(ArgAction::Set)
-                    .required(false),
-            )
-            .arg(
-                Arg::new("file-path")
-                    .value_parser(clap::value_parser!(std::path::PathBuf))
-                    .action(ArgAction::Set)
-                    .required(false),
-            );
-
-        let _ = execute(&m.get_matches_from(vec!["myapp", "true", &file_path]));
-        assert_eq!(path.exists(), false);
-    }
 }

--- a/src/cmd/install.rs
+++ b/src/cmd/install.rs
@@ -12,16 +12,4 @@ pub fn make_subcommand() -> Command {
                 .action(ArgAction::Append)
                 .help("The name of a Tembo stack type to install"),
         )
-        .arg(
-            Arg::new("file-path")
-                .short('f')
-                .long("file-path")
-                .value_name("dir")
-                .value_parser(clap::value_parser!(std::path::PathBuf))
-                .action(ArgAction::Append)
-                .help(
-                    "A path to the directory to add to the configuration \
-                    file to, default is $HOME/.config/tembo",
-                ),
-        )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,9 @@ const WINDOWS_ERROR_MSG: &str = "- Windows is not supported at this time";
 
 fn main() {
     let command = create_clap_command();
+    let matches = command.get_matches();
 
-    // Check which subcommand the user ran...
-    let res = match command.get_matches().subcommand() {
+    let res = match matches.subcommand() {
         Some(("init", sub_matches)) => cmd::init::execute(sub_matches),
         Some(("install", sub_matches)) => cmd::stack::create::execute(sub_matches),
         Some(("stack", sub_matches)) => cmd::stack::create::execute(sub_matches),
@@ -45,7 +45,6 @@ fn main() {
         println!("{}", res.err().unwrap());
 
         // TODO: adding logging, log error
-        //
         std::process::exit(101);
     }
 }
@@ -54,7 +53,7 @@ fn main() {
 fn create_clap_command() -> Command {
     Command::new(crate_name!())
         .about(crate_description!())
-        .author("Tembo.io")
+        .author("Tembo <ry@tembo.io>")
         .version(VERSION)
         .propagate_version(true)
         .arg_required_else_help(true)

--- a/test/dryrun/test.toml
+++ b/test/dryrun/test.toml
@@ -1,0 +1,4 @@
+file_name = "configuration.toml"
+file_path = "/Users/mkrisher/projects/tembo-cli/./test/dryrun/test.toml"
+
+[stacks]


### PR DESCRIPTION
This PR updates the Config file to read and write toml structure rather than just appending strings. This will be used as we enumerate through stacks and extensions in the future.

Also fixes a bug where the install command was broken in the process of making it an alias of `stack create`