### PR TITLE
[tem-1675] init config structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/**
+tests/.config/tembo/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,16 +120,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.78"
+name = "bumpalo"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d9d13be47a5b7c3907137f1290b0459a7f80efb26be8c52afb11963bccb02"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "time",
+ "wasm-bindgen",
+ "windows-targets 0.48.0",
+]
 
 [[package]]
 name = "clap"
@@ -159,6 +199,12 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "difflib"
@@ -260,6 +306,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +411,12 @@ name = "linux-raw-sys"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "maplit"
@@ -370,7 +454,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -514,7 +598,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -586,7 +670,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -601,11 +685,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tembo"
 version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "chrono",
  "clap",
  "clap_complete",
  "home",
@@ -634,6 +730,17 @@ name = "termtree"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
 
 [[package]]
 name = "toml"
@@ -694,6 +801,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ spinners = "4.1.0"
 semver = "1.0.18"
 mockall = "0.11.4"
 toml = "0.7.6"
+chrono = { version = "0.4.29", features = ["serde"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.8"

--- a/src/cli/cloud_account.rs
+++ b/src/cli/cloud_account.rs
@@ -1,0 +1,11 @@
+use serde::Deserialize;
+use serde::Serialize;
+use std::cmp::PartialEq;
+use toml::value::Datetime;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct CloudAccount {
+    pub name: Option<String>,
+    pub username: Option<String>,
+    pub created_at: Option<Datetime>,
+}

--- a/src/cli/cluster.rs
+++ b/src/cli/cluster.rs
@@ -1,0 +1,28 @@
+use chrono::prelude::*;
+use serde::Deserialize;
+use serde::Serialize;
+use std::cmp::PartialEq;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Cluster {
+    pub name: Option<String>,
+    pub r#type: Option<String>,
+    pub version: Option<String>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub installed_extensions: Vec<InstalledExtensions>,
+    pub enabled_extensions: Vec<EnabledExtensions>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct InstalledExtensions {
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub created_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct EnabledExtensions {
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub created_at: Option<DateTime<Utc>>,
+}

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -12,6 +12,7 @@ use std::fmt;
 use std::fs;
 use std::fs::File;
 use std::io::{Read, Write};
+use std::path::Path;
 use std::path::PathBuf;
 
 const CONFIG_FILE_NAME: &str = "configuration.toml";
@@ -48,8 +49,8 @@ impl Config {
                     clusters: vec![],
                 };
 
-                let _init = Self::init(&config, &file_path);
-                let _write = Self::write(&config, &file_path);
+                let _init = Self::init(&config, file_path);
+                let _write = Self::write(&config, file_path);
 
                 config
             }
@@ -116,8 +117,8 @@ impl Config {
     }
 
     // Initializes the config file, creating the directories and files as needed
-    fn init(&self, file_path: &PathBuf) -> Result<(), Box<dyn Error>> {
-        let mut dir_path = file_path.clone();
+    fn init(&self, file_path: &Path) -> Result<(), Box<dyn Error>> {
+        let mut dir_path = file_path.to_path_buf();
         dir_path.pop(); // removes any filename and extension
 
         match Config::create_config_dir(&dir_path.to_string_lossy()) {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,9 +1,11 @@
 #![allow(dead_code)]
 
+use crate::cli::cloud_account::CloudAccount;
+use crate::cli::cluster::Cluster;
+use chrono::prelude::*;
 use clap::ArgMatches;
 use serde::Deserialize;
 use serde::Serialize;
-use std::cmp::PartialEq;
 use std::env;
 use std::error::Error;
 use std::fmt;
@@ -13,33 +15,14 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 
 const CONFIG_FILE_NAME: &str = "configuration.toml";
+const CONFIG_FILE_PATH: &str = ".config/tembo/";
 
 // NOTE: modifying the struct determines what gets persisted in the configuration file
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
-    pub file_name: String,
-    pub file_path: PathBuf, // NOTE: may support additional file paths in the future (ie. for an individual project or having multiple accounts for example)
-    pub stacks: Stacks,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct Stacks {
-    pub name: Option<String>,
-    pub version: Option<String>,
-    pub installed_extensions: InstalledExtensions,
-    pub enabled_extensions: EnabledExtensions,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct InstalledExtensions {
-    pub name: Option<String>,
-    pub version: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct EnabledExtensions {
-    pub name: Option<String>,
-    pub version: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub cloud_account: Option<CloudAccount>,
+    pub clusters: Vec<Cluster>,
 }
 
 impl fmt::Display for Config {
@@ -52,39 +35,30 @@ impl fmt::Display for Config {
 
 impl Config {
     // Returns a default Rust object that will be persisted as serialized toml
-    pub fn new(args: &ArgMatches) -> Config {
-        match Self::read_to_string(args) {
+    pub fn new(_args: &ArgMatches, file_path: &PathBuf) -> Config {
+        let utc: DateTime<Utc> = Utc::now();
+
+        match Self::read_to_string(file_path) {
             Ok(contents) => Self::to_toml(&contents),
             Err(_) => {
+                // NOTE: the defaults that get written to the configuration file
                 let config = Config {
-                    file_name: CONFIG_FILE_NAME.to_string(),
-                    file_path: Self::full_path(args),
-                    stacks: Stacks {
-                        name: None,
-                        version: None,
-                        installed_extensions: InstalledExtensions {
-                            name: None,
-                            version: None,
-                        },
-                        enabled_extensions: EnabledExtensions {
-                            name: None,
-                            version: None,
-                        },
-                    },
+                    created_at: utc,
+                    cloud_account: None,
+                    clusters: vec![],
                 };
 
-                let _ = Self::init(&config);
-                let _ = Self::write(&config);
+                let _init = Self::init(&config, &file_path);
+                let _write = Self::write(&config, &file_path);
 
                 config
             }
         }
     }
 
-    // Reads the contents of any existing config file and returns contents as a string
-    pub fn read_to_string(args: &ArgMatches) -> Result<String, Box<dyn Error>> {
-        let file = Self::full_path(args);
-        let mut file = File::open(file)?;
+    // Reads the contents of an existing config file and returns contents as a string
+    pub fn read_to_string(file_path: &PathBuf) -> Result<String, Box<dyn Error>> {
+        let mut file = File::open(file_path)?;
         let mut contents = String::new();
 
         file.read_to_string(&mut contents)
@@ -101,14 +75,30 @@ impl Config {
     }
 
     // Writes the current Config to the config file, overwriting anything else that was there
-    pub fn write(&self) -> Result<(), Box<dyn Error>> {
-        let file_path = self.file_path.clone();
-
+    pub fn write(&self, file_path: &PathBuf) -> Result<(), Box<dyn Error>> {
         let mut file = File::create(file_path)?;
         let _delete = file.set_len(0); // this deletes all contents from the file
+
         let _result = file.write_all(self.to_string().as_bytes());
 
         Ok(())
+    }
+
+    // Returns the full path to the config file
+    pub fn full_path(_args: &ArgMatches) -> PathBuf {
+        // NOTE: only supporting a file in the home directory for now
+        let home_dir = home::home_dir();
+
+        // if home directory can not be determined, use the current directory
+        match home_dir {
+            Some(mut path) => {
+                path.push(CONFIG_FILE_PATH);
+                path.push(CONFIG_FILE_NAME);
+
+                path
+            }
+            None => env::current_dir().expect("Unable to determine the current directory"),
+        }
     }
 
     // Creates the config directory
@@ -119,37 +109,19 @@ impl Config {
     }
 
     // Creates the config file in the config directory
-    fn create_config_file(path: String) -> Result<(), Box<dyn Error>> {
+    fn create_config_file(path: &str) -> Result<(), Box<dyn Error>> {
         File::create_new(path)?; // don't overwrite existing file at path
 
         Ok(())
     }
 
-    // Returns the full path to the config file
-    fn full_path(_args: &ArgMatches) -> PathBuf {
-        // NOTE: only supporting a file in the home directory for now
-        let home_dir = home::home_dir();
-
-        // if home directory can not be determined, use the current directory
-        match home_dir {
-            Some(mut path) => {
-                path.push(".config");
-                path.push("tembo");
-                path.push(CONFIG_FILE_NAME);
-
-                path
-            }
-            None => env::current_dir().expect("Unable to determine the current directory"),
-        }
-    }
-
     // Initializes the config file, creating the directories and files as needed
-    fn init(&self) -> Result<(), Box<dyn Error>> {
-        let mut full_path = self.file_path.clone();
-        full_path.pop(); // removes any filename and extension
+    fn init(&self, file_path: &PathBuf) -> Result<(), Box<dyn Error>> {
+        let mut dir_path = file_path.clone();
+        dir_path.pop(); // removes any filename and extension
 
-        match Config::create_config_dir(&full_path.to_string_lossy()) {
-            Ok(()) => Config::create_config_file(self.file_path.to_string_lossy().into_owned()),
+        match Config::create_config_dir(&dir_path.to_string_lossy()) {
+            Ok(()) => Config::create_config_file(&file_path.to_string_lossy()),
             Err(e) => {
                 println!("- Directory can not be created, {}", e);
 
@@ -162,30 +134,27 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::cluster::Cluster;
+    use crate::cli::cluster::EnabledExtensions;
+    use crate::cli::cluster::InstalledExtensions;
     use crate::cli::config::Config;
     use clap::{Arg, ArgAction, Command};
     use std::env;
-    use std::io::Read;
 
-    // NOTE: many of the tests below assume the config file is in place, this is a convenient
-    // helper to create the file if it doesn't already exist
-    fn setup() {
-        let matches = Command::new("myapp")
-            .arg(
-                Arg::new("file-path")
-                    .value_parser(clap::value_parser!(std::path::PathBuf))
-                    .action(ArgAction::Set)
-                    .required(false),
-            )
-            .get_matches_from(vec!["myapp"]);
+    fn test_path() -> PathBuf {
+        let mut path: PathBuf = env::current_dir().unwrap();
+        path.push("tests");
+        path.push(".config");
+        path.push("tembo");
 
-        let _config = Config::new(&matches); // calls init and writes the file
+        let _result = Config::create_config_dir(&path.to_string_lossy());
+
+        path.push("configuration.toml");
+
+        return path;
     }
 
-    #[test]
-    fn read_to_string_test() {
-        setup();
-
+    fn setup() -> Config {
         let matches = Command::new("myapp")
             .arg(
                 Arg::new("file-path")
@@ -195,75 +164,101 @@ mod tests {
             )
             .get_matches_from(vec!["myapp"]);
 
-        let config = Config::read_to_string(&matches);
+        let path: PathBuf = test_path();
+        let config = Config::new(&matches, &path); // calls init and writes the file
+
+        return config;
+    }
+
+    fn cleanup() {
+        let path = test_path();
+        let _ = std::fs::remove_file(&*path.to_string_lossy());
+    }
+
+    // NOTE: wrap tests that require a setup and cleanup step
+    #[test]
+    fn config_tests() {
+        setup();
+
+        init_test();
+        read_to_string_test();
+        to_toml_test();
+
+        cleanup();
+    }
+
+    fn init_test() {
+        // retrieves the full path, pops off the file_path, creates the directories if needed, and
+        // writes the file
+        let matches = Command::new("myapp")
+            .arg(
+                Arg::new("file-path")
+                    .value_parser(clap::value_parser!(std::path::PathBuf))
+                    .action(ArgAction::Set)
+                    .required(false),
+            )
+            .get_matches_from(vec!["myapp"]);
+
+        let path = test_path();
+        let _config = Config::new(&matches, &path); // calls init and writes the file
+                                                    //
+        let file = File::open(path);
+        let mut contents = String::new();
+
+        let _ = file.unwrap().read_to_string(&mut contents);
+
+        assert_eq!(contents, Config::to_toml(&contents).to_string());
+    }
+
+    fn read_to_string_test() {
+        let _matches = Command::new("myapp")
+            .arg(
+                Arg::new("file-path")
+                    .value_parser(clap::value_parser!(std::path::PathBuf))
+                    .action(ArgAction::Set)
+                    .required(false),
+            )
+            .get_matches_from(vec!["myapp"]);
+
+        let path = test_path();
+        let config = Config::read_to_string(&path);
 
         assert_eq!(config.is_ok(), true);
     }
 
-    #[test]
     fn to_toml_test() {
-        let matches = Command::new("myapp")
-            .arg(
-                Arg::new("file-path")
-                    .value_parser(clap::value_parser!(std::path::PathBuf))
-                    .action(ArgAction::Set)
-                    .required(false),
-            )
-            .get_matches_from(vec!["myapp"]);
-
-        // defaults
-        let config = Config::new(&matches);
+        let mut config = setup();
         let toml = Config::to_toml(&config.to_string());
 
-        assert_eq!(toml.file_name, CONFIG_FILE_NAME);
-        assert_eq!(
-            toml.stacks,
-            Stacks {
-                name: None,
-                version: None,
-                installed_extensions: InstalledExtensions {
-                    name: None,
-                    version: None,
-                },
-                enabled_extensions: EnabledExtensions {
-                    name: None,
-                    version: None,
-                }
-            }
-        );
+        // with no cluster instances
+        assert_eq!(toml.clusters, vec![]);
 
-        // wth stacks
-        let mut config = Config::new(&matches);
-        config.stacks = Stacks {
-            name: Some(String::from("stack_name")),
+        // wth clusters instances
+        let cluster = Cluster {
+            name: Some(String::from("cluster_name")),
+            r#type: Some(String::from("standard")),
             version: Some(String::from("1.1")),
-            installed_extensions: InstalledExtensions {
+            created_at: Some(Utc::now()),
+            installed_extensions: vec![InstalledExtensions {
                 name: Some(String::from("pgmq")),
                 version: Some(String::from("1.0")),
-            },
-            enabled_extensions: EnabledExtensions {
+                created_at: Some(Utc::now()),
+            }],
+            enabled_extensions: vec![EnabledExtensions {
                 name: Some(String::from("pgmq")),
                 version: Some(String::from("1.0")),
-            },
+                created_at: Some(Utc::now()),
+            }],
         };
+        config.clusters = vec![cluster];
 
         let toml = Config::to_toml(&config.to_string());
 
-        assert_eq!(toml.file_name, CONFIG_FILE_NAME);
+        //assert_eq!(toml.created_at.is_some(), true);
+        assert_eq!(toml.clusters[0].name, Some(String::from("cluster_name")));
         assert_eq!(
-            toml.stacks,
-            Stacks {
-                name: Some(String::from("stack_name")),
-                version: Some(String::from("1.1")),
-                installed_extensions: InstalledExtensions {
-                    name: Some(String::from("pgmq")),
-                    version: Some(String::from("1.0")),
-                },
-                enabled_extensions: EnabledExtensions {
-                    name: Some(String::from("pgmq")),
-                    version: Some(String::from("1.0")),
-                }
-            }
+            toml.clusters[0].installed_extensions[0].name,
+            Some(String::from("pgmq"))
         );
     }
 
@@ -281,69 +276,35 @@ mod tests {
         let binding = home::home_dir().unwrap();
         let home_dir = &binding.to_str().unwrap();
 
-        assert!(Config::full_path(&matches)
-            .to_str()
-            .unwrap()
-            .contains(&*home_dir));
+        let result = Config::full_path(&matches);
+
+        assert!(result.to_str().unwrap().contains(&*home_dir));
     }
 
     #[test]
     fn create_config_dir_test() {
-        let mut path: PathBuf = env::current_dir().unwrap();
-        path.push("tests");
-        path.push(".config");
+        let mut path: PathBuf = test_path();
+        path.pop();
 
-        let write = Config::create_config_dir(&path.to_string_lossy().into_owned());
+        let write = Config::create_config_dir(&path.to_string_lossy());
         assert_eq!(write.is_ok(), true);
 
-        let overwrite = Config::create_config_file(path.to_string_lossy().into_owned());
+        let overwrite = Config::create_config_file(&path.to_string_lossy());
         assert_eq!(overwrite.is_err(), true);
 
-        // clean up
-        let _ = std::fs::remove_dir(&*path.to_string_lossy());
+        cleanup();
     }
 
     #[test]
     fn create_config_file_test() {
-        let mut path: PathBuf = env::current_dir().unwrap();
-        path.push("tests");
-        path.push("configuration.toml");
+        let path: PathBuf = test_path();
 
-        let write = Config::create_config_file(path.to_string_lossy().into_owned());
+        let write = Config::create_config_file(&path.to_string_lossy());
         assert_eq!(write.is_ok(), true);
 
-        let overwrite = Config::create_config_file(path.to_string_lossy().into_owned());
+        let overwrite = Config::create_config_file(&path.to_string_lossy());
         assert_eq!(overwrite.is_err(), true);
 
-        // clean up
-        let _ = std::fs::remove_file(&*path.to_string_lossy());
-    }
-
-    #[test]
-    fn init_test() {
-        setup();
-        // retrieves the full path, pops off the file_path, creates the directories if needed, and
-        // writes the file
-        let matches = Command::new("myapp")
-            .arg(
-                Arg::new("file-path")
-                    .value_parser(clap::value_parser!(std::path::PathBuf))
-                    .action(ArgAction::Set)
-                    .required(false),
-            )
-            .get_matches_from(vec!["myapp"]);
-
-        let _config = Config::new(&matches); // calls init and writes the file
-        let path = Config::full_path(&matches);
-
-        let file = File::open(path);
-        let mut contents = String::new();
-
-        let _ = file.unwrap().read_to_string(&mut contents);
-
-        assert_eq!(contents, Config::to_toml(&contents).to_string());
-
-        // clean up
-        let _ = std::fs::remove_file(Config::full_path(&matches));
+        cleanup();
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,5 @@
+pub mod cloud_account;
+pub mod cluster;
 pub mod config;
 pub mod docker;
 pub mod stacks;

--- a/src/cli/stacks.rs
+++ b/src/cli/stacks.rs
@@ -96,10 +96,7 @@ pub fn define_stacks() -> Stacks {
     file.read_to_string(&mut contents)
         .expect("Unable to read stack config file");
 
-    // TODO: harden, don't use unerap in production
-    let clusters = serde_yaml::from_str(&contents).unwrap();
-
-    clusters
+    serde_yaml::from_str(&contents).unwrap()
 }
 
 #[cfg(test)]

--- a/src/cli/stacks.rs
+++ b/src/cli/stacks.rs
@@ -97,9 +97,9 @@ pub fn define_stacks() -> Stacks {
         .expect("Unable to read stack config file");
 
     // TODO: harden, don't use unerap in production
-    let stacks: Stacks = serde_yaml::from_str(&contents).unwrap();
+    let clusters = serde_yaml::from_str(&contents).unwrap();
 
-    stacks
+    clusters
 }
 
 #[cfg(test)]

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -9,7 +9,7 @@ pub fn make_subcommand() -> Command {
 }
 
 pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
-    let config = Config::new(args, &Config::full_path(&args));
+    let config = Config::new(args, &Config::full_path(args));
 
     println!(
         "- config file created at: {}",

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -9,11 +9,11 @@ pub fn make_subcommand() -> Command {
 }
 
 pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
-    let config = Config::new(args);
+    let config = Config::new(args, &Config::full_path(&args));
 
     println!(
         "- config file created at: {}",
-        &config.file_path.to_string_lossy()
+        &config.created_at.to_string()
     );
 
     Ok(())

--- a/src/cmd/stack.rs
+++ b/src/cmd/stack.rs
@@ -240,7 +240,7 @@ pub mod create {
         stack: &stacks::StackDetails,
         args: &ArgMatches,
     ) -> Result<(), Box<dyn Error>> {
-        let mut config: Config = Config::new(args, &Config::full_path(&args));
+        let mut config: Config = Config::new(args, &Config::full_path(args));
         let mut cluster_config = Cluster {
             name: Some(stack.name.clone()),
             r#type: Some(String::from("standard")),

--- a/src/cmd/stack.rs
+++ b/src/cmd/stack.rs
@@ -1,7 +1,11 @@
 pub mod create {
-    use crate::cli::config::{Config, EnabledExtensions, InstalledExtensions, Stacks};
+    use crate::cli::cluster::Cluster;
+    use crate::cli::cluster::EnabledExtensions;
+    use crate::cli::cluster::InstalledExtensions;
+    use crate::cli::config::Config;
     use crate::cli::docker::{Docker, DockerError};
     use crate::cli::stacks;
+    use chrono::prelude::*;
     use clap::{Arg, ArgAction, ArgMatches, Command};
     use spinners::{Spinner, Spinners};
     use std::error::Error;
@@ -101,7 +105,7 @@ pub mod create {
             let _ = enable_extension(stack, extension);
         }
 
-        let _ = persist_stack_config(desired_stack, args);
+        let _ = persist_config(desired_stack, args);
 
         Ok(())
     }
@@ -232,42 +236,49 @@ pub mod create {
         image.is_some()
     }
 
-    fn persist_stack_config(
+    fn persist_config(
         stack: &stacks::StackDetails,
         args: &ArgMatches,
     ) -> Result<(), Box<dyn Error>> {
-        let mut config: Config = Config::new(args);
-        let mut stack_config = Stacks {
+        let mut config: Config = Config::new(args, &Config::full_path(&args));
+        let mut cluster_config = Cluster {
             name: Some(stack.name.clone()),
+            r#type: Some(String::from("standard")),
             version: Some(stack.stack_version.clone()),
-            installed_extensions: InstalledExtensions {
+            created_at: Some(Utc::now()),
+            installed_extensions: vec![InstalledExtensions {
                 name: None,
                 version: None,
-            },
-            enabled_extensions: EnabledExtensions {
+                created_at: Some(Utc::now()),
+            }],
+            enabled_extensions: vec![EnabledExtensions {
                 name: None,
                 version: None,
-            },
+                created_at: Some(Utc::now()),
+            }],
         };
 
         for install in &stack.trunk_installs {
-            stack_config.installed_extensions = InstalledExtensions {
-                name: Some(install.name.clone()),
-                version: Some(install.version.clone()),
-            }
+            cluster_config
+                .installed_extensions
+                .push(InstalledExtensions {
+                    name: Some(install.name.clone()),
+                    version: Some(install.version.clone()),
+                    created_at: Some(Utc::now()),
+                })
         }
 
-        // TODO: don't overwrite the trunk installs, add or modify them
         for extension in &stack.extensions {
-            stack_config.enabled_extensions = EnabledExtensions {
+            cluster_config.enabled_extensions.push(EnabledExtensions {
                 name: Some(extension.name.clone()),
                 version: Some(String::from("2.0")),
-            }
+                created_at: Some(Utc::now()),
+            })
         }
 
-        config.stacks = stack_config;
+        config.clusters = vec![cluster_config];
 
-        match Config::write(&config) {
+        match Config::write(&config, &Config::full_path(args)) {
             Ok(_) => println!("- Stack install info added to configuration file"),
             Err(e) => eprintln!("{}", e),
         }
@@ -332,7 +343,7 @@ pub mod create {
 
         #[test]
         #[ignore]
-        fn persist_stack_config_test() {
+        fn persist_config_test() {
             let stack_type = String::from("standard");
             let trunk_install = TrunkInstall {
                 name: String::from("pgmq"),
@@ -368,7 +379,7 @@ pub mod create {
             );
 
             let matches = &m.get_matches_from(vec!["myapp", "create", "--stack", &stack_type]);
-            let result = persist_stack_config(&stack, &matches);
+            let result = persist_config(&stack, &matches);
 
             assert_eq!(result.is_ok(), true);
 

--- a/test/dryrun/test.toml
+++ b/test/dryrun/test.toml
@@ -1,4 +1,0 @@
-file_name = "configuration.toml"
-file_path = "/Users/mkrisher/projects/tembo-cli/./test/dryrun/test.toml"
-
-[stacks]


### PR DESCRIPTION
This PR refactors the configuration file structure, it renames stacks to clusters in the context of the configuration file (more to come). The default config file now looks like:

```
bat ~/.config/tembo/configuration.toml
─────────────────────────────
       │ File: ~/.config/tembo/configuration.toml
─────────────────────────────
   1   │ created_at = "2023-09-06T17:12:56.282625Z"
   2   │ clusters = []
```

The config file is now set up to persist the configuration of multiple instances of a cluster type, including installed and enabled extensions.

This lays the foundation for allowing users to run multiple instances of the same cluster stack. We'll persist the configuration, including names and various ports.