### PR TITLE
[tem-1674] Updates init command to check requirements

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,4 +1,5 @@
 use crate::cli::config::Config;
+use crate::cli::docker::Docker;
 use clap::{ArgMatches, Command};
 use std::error::Error;
 
@@ -12,9 +13,20 @@ pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
     let config = Config::new(args, &Config::full_path(args));
 
     println!(
-        "- config file created at: {}",
+        "- Config file created at: {}",
         &config.created_at.to_string()
     );
 
+    match check_requirements() {
+        Ok(_) => println!("- Docker was found and appears running"),
+        Err(e) => {
+            return Err(e);
+        }
+    }
+
     Ok(())
+}
+
+fn check_requirements() -> Result<(), Box<dyn Error>> {
+    Docker::installed_and_running()
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -18,11 +18,9 @@ fn help() -> Result<(), Box<dyn std::error::Error>> {
 fn init() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
     cmd.arg("init");
-    cmd.assert().stdout(predicate::str::contains("config file"));
-
-    // TODO: test that the configuration file is created
+    cmd.assert().stdout(predicate::str::contains("Config file"));
+    cmd.assert()
+        .stdout(predicate::str::contains("Checking requirements"));
 
     Ok(())
 }
-
-// TODO: add integration test for install command


### PR DESCRIPTION
This PR updates the init command to check the user's system for the requirements, mainly that docker is installed and running. This same check will be done before clusters are created, but it's nice to put up front so users can install the requirements when they first start.

```
cargo run -- init
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/tembo init`
- Config file created at: 2023-09-06 17:12:56.282625 UTC
- Checking requirements: [Docker]
- Docker is not running, please start it and try again
```