### PR TITLE
[tem-1673] Updates init command to pull Docker image

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,15 +1,33 @@
 use crate::cli::config::Config;
-use crate::cli::docker::Docker;
+use crate::cli::docker::{Docker, DockerError};
 use clap::{ArgMatches, Command};
+use spinners::{Spinner, Spinners};
 use std::error::Error;
+use std::process::Command as ShellCommand;
 
 // Create clap subcommand arguments
 pub fn make_subcommand() -> Command {
     Command::new("init")
-        .about("Initializes a local environment or project; generates configuration")
+        .about("Initializes a local environment; generates configuration and pulls Docker image")
 }
 
 pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    // alert that windows is not supported yet
+    if cfg!(target_os = "windows") {
+        println!("{}", crate::WINDOWS_ERROR_MSG);
+
+        return Err(Box::new(DockerError::new(crate::WINDOWS_ERROR_MSG)));
+    }
+
+    // check the system requirements
+    match check_requirements() {
+        Ok(_) => println!("- Docker was found and appears running"),
+        Err(e) => {
+            return Err(e);
+        }
+    }
+
+    // create the configuration file in the default location
     let config = Config::new(args, &Config::full_path(args));
 
     println!(
@@ -17,9 +35,11 @@ pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
         &config.created_at.to_string()
     );
 
-    match check_requirements() {
-        Ok(_) => println!("- Docker was found and appears running"),
+    // pull the Tembo image
+    match build_image() {
+        Ok(_) => println!("- Tembo image is installed"),
         Err(e) => {
+            eprintln!("{}", e);
             return Err(e);
         }
     }
@@ -29,4 +49,50 @@ pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
 
 fn check_requirements() -> Result<(), Box<dyn Error>> {
     Docker::installed_and_running()
+}
+
+fn build_image() -> Result<(), Box<dyn Error>> {
+    if image_exist() {
+        println!("- Tembo image already exists, proceeding");
+        return Ok(());
+    }
+
+    let mut sp = Spinner::new(Spinners::Line, "Installing image".into());
+    let mut command = String::from("cd tembo"); // TODO: does this work for installed crates?
+    command.push_str("&& docker image pull ");
+    command.push_str("quay.io/tembo/tembo-pg-cnpg:latest");
+    command.push_str(" --quiet");
+
+    let output = ShellCommand::new("sh")
+        .arg("-c")
+        .arg(&command)
+        .output()
+        .expect("failed to execute process");
+
+    sp.stop_with_message("- Tembo image install complete".into());
+
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    if !stderr.is_empty() {
+        return Err(Box::new(DockerError::new(
+            format!("There was an issue pulling the image: {}", stderr).as_str(),
+        )));
+    } else {
+        Ok(())
+    }
+}
+
+fn image_exist() -> bool {
+    let command = String::from("docker images");
+    let output = ShellCommand::new("sh")
+        .arg("-c")
+        .arg(&command)
+        .output()
+        .expect("failed to execute process");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let image_name = String::from("tembo-pg-cnpg");
+    let image = stdout.find(&image_name);
+
+    image.is_some()
 }


### PR DESCRIPTION
This PR updates the init command to:

- alert Windows users that it is not supported yet (new)
- check for requirements
- pull Tembo Docker image (new)
- create configuration file if it doesn't exist

Note: Most of the code was pulled over from the stack create command file pushing it further up in the process. The logic is removed from the stack file in another PR. #15 