### PR TITLE
[tem-1548][tem-1550] instance list & instance start

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tembo"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "The CLI for Tembo"

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ The `instance create` command creates an instance of a Tembo stack locally. It i
 version of Postgres and an additional items like extensions. You can specify the 
 type of instance you want to create. You'll also need to provide a name and port number.
 
-Each instance runs as a Docker container.
-
 Currently supported types include: 
 
 * standard
@@ -39,9 +37,16 @@ Currently supported types include:
 
 More stack types will be added shortly.
 
+## `tembo instance list`
+
+The `instance list` command simply lists all of the instances that have been created. It lists key attributes such as name, type and port.
+
 ## `tembo instance start`
 
-Coming soon - will start an installed instance.
+The `instance start` command allows users to start their instances. It requires the name as a parameter and Docker to be running. No two 
+instances can be started that share a port number.
+
+Each instance runs as a Docker container.
 
 # Contributing
 

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -44,7 +44,12 @@ pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    Ok(())
+    match build_image() {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            return Err(e);
+        }
+    }
 }
 
 fn check_requirements() -> Result<(), Box<dyn Error>> {

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -36,20 +36,7 @@ pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
     );
 
     // pull the Tembo image
-    match build_image() {
-        Ok(_) => println!("- Tembo image is installed"),
-        Err(e) => {
-            eprintln!("{}", e);
-            return Err(e);
-        }
-    }
-
-    match build_image() {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            return Err(e);
-        }
-    }
+    build_image()
 }
 
 fn check_requirements() -> Result<(), Box<dyn Error>> {

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -59,8 +59,7 @@ fn build_image() -> Result<(), Box<dyn Error>> {
 
     let mut sp = Spinner::new(Spinners::Line, "Installing image".into());
     let mut command = String::from("cd tembo"); // TODO: does this work for installed crates?
-    command.push_str("&& docker image pull ");
-    command.push_str("quay.io/tembo/tembo-pg-cnpg:latest");
+    command.push_str("&& docker build -t tembo-pg . ");
     command.push_str(" --quiet");
 
     let output = ShellCommand::new("sh")

--- a/src/cmd/instance.rs
+++ b/src/cmd/instance.rs
@@ -7,9 +7,7 @@ pub mod create {
     use crate::cli::stacks::Stacks;
     use chrono::prelude::*;
     use clap::{Arg, ArgAction, ArgMatches, Command};
-    //use spinners::{Spinner, Spinners};
     use std::error::Error;
-    //use std::process::Command as ShellCommand;
 
     // example usage: tembo instance create -t oltp -n my_app_db -p 5432
     pub fn make_subcommand() -> Command {
@@ -63,7 +61,7 @@ pub mod create {
                 }
             }
 
-            match persist_instance_config(&matches) {
+            match persist_instance_config(matches) {
                 Ok(_) => println!("- Instance config persisted in config file"),
                 Err(e) => {
                     eprintln!("{}", e);

--- a/src/cmd/instance.rs
+++ b/src/cmd/instance.rs
@@ -7,7 +7,9 @@ pub mod create {
     use crate::cli::stacks::Stacks;
     use chrono::prelude::*;
     use clap::{Arg, ArgAction, ArgMatches, Command};
+    //use spinners::{Spinner, Spinners};
     use std::error::Error;
+    //use std::process::Command as ShellCommand;
 
     // example usage: tembo instance create -t oltp -n my_app_db -p 5432
     pub fn make_subcommand() -> Command {
@@ -61,7 +63,7 @@ pub mod create {
                 }
             }
 
-            match persist_instance_config(matches) {
+            match persist_instance_config(&matches) {
                 Ok(_) => println!("- Instance config persisted in config file"),
                 Err(e) => {
                     eprintln!("{}", e);
@@ -132,7 +134,6 @@ pub mod create {
         }
 
         config.instances.push(instance);
-
         let _ = config.write(&Config::full_path(matches));
 
         Ok(())

--- a/src/cmd/instance.rs
+++ b/src/cmd/instance.rs
@@ -1,191 +1,33 @@
-pub mod create {
-    use crate::cli::config::Config;
-    use crate::cli::docker::{Docker, DockerError};
-    use crate::cli::instance::{EnabledExtension, InstalledExtension, Instance};
-    use crate::cli::stack_error::StackError;
-    use crate::cli::stacks;
-    use crate::cli::stacks::Stacks;
-    use chrono::prelude::*;
-    use clap::{Arg, ArgAction, ArgMatches, Command};
-    use std::error::Error;
+use crate::cli::docker::DockerError;
+use clap::ArgMatches;
+use std::error::Error;
 
-    // example usage: tembo instance create -t oltp -n my_app_db -p 5432
-    pub fn make_subcommand() -> Command {
-        Command::new("create")
-            .about("Command used to create a local instance")
-            .arg(
-                Arg::new("type")
-                    .short('t')
-                    .long("type")
-                    .action(ArgAction::Set)
-                    .required(false)
-                    .default_value("standard")
-                    .help("The name of a Tembo stack type to use"),
-            )
-            .arg(
-                Arg::new("name")
-                    .short('n')
-                    .long("name")
-                    .action(ArgAction::Set)
-                    .required(true)
-                    .help("The name you want to use for this instance"),
-            )
-            .arg(
-                Arg::new("port")
-                    .short('p')
-                    .long("port")
-                    .action(ArgAction::Set)
-                    .required(false)
-                    .default_value("5432")
-                    .help("The port number you want to use for this instance (default is 5432)"),
-            )
+pub mod create;
+pub mod list;
+pub mod start;
+
+// handles all instance command calls
+pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    if cfg!(target_os = "windows") {
+        println!("{}", crate::WINDOWS_ERROR_MSG);
+
+        return Err(Box::new(DockerError::new(crate::WINDOWS_ERROR_MSG)));
     }
 
-    pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
-        if cfg!(target_os = "windows") {
-            println!("{}", crate::WINDOWS_ERROR_MSG);
+    // execute the instance subcommands
+    let res = match args.subcommand() {
+        Some(("create", sub_matches)) => create::execute(sub_matches),
+        Some(("list", sub_matches)) => list::execute(sub_matches),
+        Some(("start", sub_matches)) => start::execute(sub_matches),
+        _ => unreachable!(),
+    };
 
-            return Err(Box::new(DockerError::new(crate::WINDOWS_ERROR_MSG)));
-        }
+    if res.is_err() {
+        println!("{}", res.err().unwrap());
 
-        let (_name, matches) = args.subcommand().unwrap();
-
-        // ensure the stack type provided is valid, if none given, default to the standard stack
-        if let Ok(_stack) = stacks::define_stack(matches) {
-            // make sure requirements are met
-            match check_requirements() {
-                Ok(_) => println!("- Docker was found and appears running"),
-                Err(e) => {
-                    eprintln!("{}", e);
-                    return Err(e);
-                }
-            }
-
-            match persist_instance_config(matches) {
-                Ok(_) => println!("- Instance config persisted in config file"),
-                Err(e) => {
-                    eprintln!("{}", e);
-                    return Err(e);
-                }
-            }
-
-            println!(
-                "- Instance configuration created, you can start the instance using the command 'tembo start -i <name>'"
-            );
-        } else {
-            return Err(Box::new(StackError::new("- Given Stack type is not valid")));
-        }
-
-        Ok(())
+        // TODO: adding logging, log error
+        std::process::exit(101);
     }
 
-    fn check_requirements() -> Result<(), Box<dyn Error>> {
-        Docker::installed_and_running()
-    }
-
-    fn persist_instance_config(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
-        let path = Config::full_path(matches);
-        let mut config = Config::new(matches, &path); // calls init and writes the file
-
-        let r#type = matches.get_one::<String>("type").unwrap();
-        let name = matches.get_one::<String>("name").unwrap();
-        let port = matches.get_one::<String>("port").unwrap();
-
-        let mut instance = Instance {
-            name: Some(name.to_string()),
-            r#type: Some(r#type.to_string()),
-            port: Some(port.to_string()),
-            created_at: Some(Utc::now()),
-            version: None,
-            installed_extensions: vec![],
-            enabled_extensions: vec![],
-        };
-
-        let stacks: Stacks = stacks::define_stacks();
-
-        for stack in stacks.stacks {
-            if stack.name.to_lowercase() == r#type.to_lowercase() {
-                // populate fields of instance
-                instance.version = Some(stack.version);
-
-                for install in stack.trunk_installs {
-                    let installed_extension = InstalledExtension {
-                        name: install.name,
-                        version: install.version,
-                        created_at: install.created_at,
-                    };
-
-                    instance.installed_extensions.push(installed_extension);
-                }
-
-                for extension in stack.extensions {
-                    let enabled_extension = EnabledExtension {
-                        name: extension.name,
-                        version: extension.version,
-                        created_at: extension.created_at,
-                        locations: vec![],
-                    };
-
-                    instance.enabled_extensions.push(enabled_extension);
-                }
-            }
-        }
-
-        config.instances.push(instance);
-        let _ = config.write(&Config::full_path(matches));
-
-        Ok(())
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use clap::{Arg, ArgAction, Command};
-
-        #[test]
-        fn valid_execute_test() {
-            // with a valid stack type
-            let stack_type = String::from("standard");
-
-            let m = Command::new("myapp").subcommand(
-                Command::new("create")
-                    .arg(
-                        Arg::new("type")
-                            .short('t')
-                            .long("type")
-                            .action(ArgAction::Set)
-                            .required(false)
-                            .default_value("standard")
-                            .help("The name of a Tembo stack type to create an instance of"),
-                    )
-                    .arg(
-                        Arg::new("name")
-                            .short('n')
-                            .long("name")
-                            .action(ArgAction::Set)
-                            .required(true)
-                            .help("The name you want to give your instance"),
-                    )
-                    .arg(
-                        Arg::new("port")
-                            .short('p')
-                            .long("port")
-                            .action(ArgAction::Set)
-                            .required(false)
-                            .default_value("5432")
-                            .help("The port number you want the instance to run on"),
-                    ),
-            );
-
-            let result = execute(&m.get_matches_from(vec![
-                "myapp",
-                "create",
-                "-t",
-                &stack_type,
-                "-n",
-                "test",
-            ]));
-            assert_eq!(result.is_ok(), true);
-        }
-    }
+    Ok(())
 }

--- a/src/cmd/instance/create.rs
+++ b/src/cmd/instance/create.rs
@@ -87,6 +87,8 @@ fn persist_instance_config(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
     let path = Config::full_path(matches);
     let mut config = Config::new(matches, &path); // calls init and writes the file
 
+    dbg!(&matches);
+
     let r#type = matches.get_one::<String>("type").unwrap();
     let name = matches.get_one::<String>("name").unwrap();
     let port = matches.get_one::<String>("port").unwrap();
@@ -148,38 +150,41 @@ mod tests {
         // with a valid stack type
         let stack_type = String::from("standard");
 
-        let m = Command::new("myapp").subcommand(
-            Command::new("create")
-                .arg(
-                    Arg::new("type")
-                        .short('t')
-                        .long("type")
-                        .action(ArgAction::Set)
-                        .required(false)
-                        .default_value("standard")
-                        .help("The name of a Tembo stack type to create an instance of"),
-                )
-                .arg(
-                    Arg::new("name")
-                        .short('n')
-                        .long("name")
-                        .action(ArgAction::Set)
-                        .required(true)
-                        .help("The name you want to give your instance"),
-                )
-                .arg(
-                    Arg::new("port")
-                        .short('p')
-                        .long("port")
-                        .action(ArgAction::Set)
-                        .required(false)
-                        .default_value("5432")
-                        .help("The port number you want the instance to run on"),
-                ),
-        );
+        let m = Command::new("create")
+            .arg(
+                Arg::new("type")
+                    .short('t')
+                    .long("type")
+                    .action(ArgAction::Set)
+                    .required(true)
+                    .help("The name of a Tembo stack type to create an instance of"),
+            )
+            .arg(
+                Arg::new("name")
+                    .short('n')
+                    .long("name")
+                    .action(ArgAction::Set)
+                    .required(true)
+                    .help("The name you want to give your instance"),
+            )
+            .arg(
+                Arg::new("port")
+                    .short('p')
+                    .long("port")
+                    .action(ArgAction::Set)
+                    .required(true)
+                    .help("The port number you want the instance to run on"),
+            );
 
-        let result =
-            execute(&m.get_matches_from(vec!["myapp", "create", "-t", &stack_type, "-n", "test"]));
+        let result = execute(&m.get_matches_from(vec![
+            "create",
+            "-t",
+            &stack_type,
+            "-n",
+            "test",
+            "-p",
+            "5432",
+        ]));
         assert_eq!(result.is_ok(), true);
     }
 }

--- a/src/cmd/instance/create.rs
+++ b/src/cmd/instance/create.rs
@@ -1,0 +1,185 @@
+// instance create command
+use crate::cli::config::Config;
+use crate::cli::docker::{Docker, DockerError};
+use crate::cli::instance::{EnabledExtension, InstalledExtension, Instance};
+use crate::cli::stack_error::StackError;
+use crate::cli::stacks;
+use crate::cli::stacks::Stacks;
+use chrono::prelude::*;
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use std::error::Error;
+
+// example usage: tembo instance create -t oltp -n my_app_db -p 5432
+pub fn make_subcommand() -> Command {
+    Command::new("create")
+        .about("Command used to create a local instance")
+        .arg(
+            Arg::new("type")
+                .short('t')
+                .long("type")
+                .action(ArgAction::Set)
+                .required(false)
+                .default_value("standard")
+                .help("The name of a Tembo stack type to use"),
+        )
+        .arg(
+            Arg::new("name")
+                .short('n')
+                .long("name")
+                .action(ArgAction::Set)
+                .required(true)
+                .help("The name you want to use for this instance"),
+        )
+        .arg(
+            Arg::new("port")
+                .short('p')
+                .long("port")
+                .action(ArgAction::Set)
+                .required(false)
+                .default_value("5432")
+                .help("The port number you want to use for this instance (default is 5432)"),
+        )
+}
+
+pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    if cfg!(target_os = "windows") {
+        println!("{}", crate::WINDOWS_ERROR_MSG);
+
+        return Err(Box::new(DockerError::new(crate::WINDOWS_ERROR_MSG)));
+    }
+
+    let matches = args;
+
+    // ensure the stack type provided is valid, if none given, default to the standard stack
+    if let Ok(_stack) = stacks::define_stack(matches) {
+        // make sure requirements are met
+        match check_requirements() {
+            Ok(_) => println!("- Docker was found and appears running"),
+            Err(e) => {
+                eprintln!("{}", e);
+                return Err(e);
+            }
+        }
+
+        match persist_instance_config(matches) {
+            Ok(_) => println!("- Instance config persisted in config file"),
+            Err(e) => {
+                eprintln!("{}", e);
+                return Err(e);
+            }
+        }
+
+        println!(
+                "- Instance configuration created, you can start the instance using the command 'tembo start -i <name>'"
+            );
+    } else {
+        return Err(Box::new(StackError::new("- Given Stack type is not valid")));
+    }
+
+    Ok(())
+}
+
+fn check_requirements() -> Result<(), Box<dyn Error>> {
+    Docker::installed_and_running()
+}
+
+fn persist_instance_config(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let path = Config::full_path(matches);
+    let mut config = Config::new(matches, &path); // calls init and writes the file
+
+    let r#type = matches.get_one::<String>("type").unwrap();
+    let name = matches.get_one::<String>("name").unwrap();
+    let port = matches.get_one::<String>("port").unwrap();
+
+    let mut instance = Instance {
+        name: Some(name.to_string()),
+        r#type: Some(r#type.to_string()),
+        port: Some(port.to_string()),
+        created_at: Some(Utc::now()),
+        version: None,
+        installed_extensions: vec![],
+        enabled_extensions: vec![],
+    };
+
+    let stacks: Stacks = stacks::define_stacks();
+
+    for stack in stacks.stacks {
+        if stack.name.to_lowercase() == r#type.to_lowercase() {
+            // populate fields of instance
+            instance.version = Some(stack.version);
+
+            for install in stack.trunk_installs {
+                let installed_extension = InstalledExtension {
+                    name: install.name,
+                    version: install.version,
+                    created_at: install.created_at,
+                };
+
+                instance.installed_extensions.push(installed_extension);
+            }
+
+            for extension in stack.extensions {
+                let enabled_extension = EnabledExtension {
+                    name: extension.name,
+                    version: extension.version,
+                    created_at: extension.created_at,
+                    locations: vec![],
+                };
+
+                instance.enabled_extensions.push(enabled_extension);
+            }
+        }
+    }
+
+    config.instances.push(instance);
+
+    let _ = config.write(&Config::full_path(matches));
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Arg, ArgAction, Command};
+
+    #[test]
+    fn valid_execute_test() {
+        // with a valid stack type
+        let stack_type = String::from("standard");
+
+        let m = Command::new("myapp").subcommand(
+            Command::new("create")
+                .arg(
+                    Arg::new("type")
+                        .short('t')
+                        .long("type")
+                        .action(ArgAction::Set)
+                        .required(false)
+                        .default_value("standard")
+                        .help("The name of a Tembo stack type to create an instance of"),
+                )
+                .arg(
+                    Arg::new("name")
+                        .short('n')
+                        .long("name")
+                        .action(ArgAction::Set)
+                        .required(true)
+                        .help("The name you want to give your instance"),
+                )
+                .arg(
+                    Arg::new("port")
+                        .short('p')
+                        .long("port")
+                        .action(ArgAction::Set)
+                        .required(false)
+                        .default_value("5432")
+                        .help("The port number you want the instance to run on"),
+                ),
+        );
+
+        let result =
+            execute(&m.get_matches_from(vec!["myapp", "create", "-t", &stack_type, "-n", "test"]));
+        assert_eq!(result.is_ok(), true);
+    }
+}

--- a/src/cmd/instance/list.rs
+++ b/src/cmd/instance/list.rs
@@ -1,0 +1,40 @@
+// instance list command
+use crate::cli::config::Config;
+use crate::cli::docker::DockerError;
+use clap::{ArgMatches, Command};
+use std::error::Error;
+
+// example usage: tembo instance create -t oltp -n my_app_db -p 5432
+pub fn make_subcommand() -> Command {
+    Command::new("list").about("Command used to list local instances")
+}
+
+pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    if cfg!(target_os = "windows") {
+        println!("{}", crate::WINDOWS_ERROR_MSG);
+
+        return Err(Box::new(DockerError::new(crate::WINDOWS_ERROR_MSG)));
+    }
+
+    let config = Config::new(args, &Config::full_path(args));
+
+    if config.instances.is_empty() {
+        println!("- No instances have been configured");
+    } else {
+        println!("- Listing of configured instances");
+
+        for instance in &config.instances {
+            println!(
+                "      {} - type: {}, port: {}",
+                instance.name.clone().unwrap(),
+                instance.r#type.clone().unwrap(),
+                instance.port.clone().unwrap()
+            );
+        }
+
+        println!("- Start an instance using `tembo instance start -n <name>`");
+        println!("- Coming soon: deploy an instance using `tembo instance deploy -n <name>`");
+    }
+
+    Ok(())
+}

--- a/src/cmd/instance/start.rs
+++ b/src/cmd/instance/start.rs
@@ -1,0 +1,83 @@
+// instance start command
+use crate::cli::config::Config;
+use crate::cli::docker::DockerError;
+use anyhow::anyhow;
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use spinners::{Spinner, Spinners};
+use std::error::Error;
+use std::process::Command as ShellCommand;
+
+// example usage: tembo instance start -n my_app_db
+pub fn make_subcommand() -> Command {
+    Command::new("start")
+        .about("Command used to start local instances")
+        .arg(
+            Arg::new("name")
+                .short('n')
+                .long("name")
+                .action(ArgAction::Set)
+                .required(true)
+                .help("The name you want to use for this instance"),
+        )
+}
+
+pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    if cfg!(target_os = "windows") {
+        println!("{}", crate::WINDOWS_ERROR_MSG);
+
+        return Err(Box::new(DockerError::new(crate::WINDOWS_ERROR_MSG)));
+    }
+
+    let config = Config::new(args, &Config::full_path(args));
+    let name = args
+        .get_one::<String>("name")
+        .ok_or_else(|| anyhow!("Name is missing."))?;
+
+    if config.instances.is_empty() {
+        println!("- No instances have been configured");
+    } else {
+        println!("- Finding config for {}", name);
+
+        for instance in &config.instances {
+            if instance.name.clone().unwrap().to_lowercase() == name.to_lowercase() {
+                println!("config has been found");
+                println!("starting via Docker");
+
+                let mut sp = Spinner::new(Spinners::Line, "Starting instance".into());
+                let port_option = format!(
+                    "--publish {}:{}",
+                    &instance.port.clone().unwrap(),
+                    &instance.port.clone().unwrap(),
+                );
+                let mut command = String::from("cd tembo "); // TODO: does this work for installed crates?
+                command.push_str("&& docker run -d --name ");
+                command.push_str(&instance.name.clone().unwrap());
+                command.push(' ');
+                command.push_str(&port_option);
+                command.push_str(" tembo-pg");
+
+                let output = ShellCommand::new("sh")
+                    .arg("-c")
+                    .arg(&command)
+                    .output()
+                    .expect("failed to execute process");
+
+                let message = format!(
+                    "- Tembo instance started on {}",
+                    &instance.port.clone().unwrap(),
+                );
+                sp.stop_with_message(message);
+
+                let stderr = String::from_utf8(output.stderr).unwrap();
+
+                if !stderr.is_empty() {
+                    return Err(Box::new(DockerError::new(
+                        format!("There was an issue starting the instance: {}", stderr).as_str(),
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
 
     let res = match matches.subcommand() {
         Some(("init", sub_matches)) => cmd::init::execute(sub_matches),
-        Some(("instance", sub_matches)) => cmd::instance::create::execute(sub_matches),
+        Some(("instance", sub_matches)) => cmd::instance::execute(sub_matches),
         Some(("completions", sub_matches)) => (|| {
             let shell = sub_matches
                 .get_one::<Shell>("shell")
@@ -64,7 +64,9 @@ fn create_clap_command() -> Command {
         .subcommand(
             Command::new("instance")
                 .about("Commands used to manage local and cloud instances")
-                .subcommand(cmd::instance::create::make_subcommand()),
+                .subcommand(cmd::instance::create::make_subcommand())
+                .subcommand(cmd::instance::list::make_subcommand())
+                .subcommand(cmd::instance::start::make_subcommand()),
         )
         .subcommand(
             Command::new("completions")


### PR DESCRIPTION
This PR introduces the `instance list` and `instance start` commands.

It changes a few things that were previously implemented associated with Docker. The `init` command no longer pulls the image, instead builds it using the local Dockerfile. The `start` command no longer uses the associated service in docker-compose. The compose file will be deleted in a future PR. The `start` command just runs a container with some dynamic properties retrieved from the configuration file. This allows users to run multiple instances in parallel. For example, two different OLAP instances can be run in parallel.

Instance subcommand are organized better now. They can be easily added via isolated files. Instance create has been moved to its own file. List and Start are their own files as well inside the instance module.