### PR TITLE
[tem-1553] Introduces db create command

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -19,6 +19,8 @@ use std::path::PathBuf;
 const CONFIG_FILE_NAME: &str = "configuration.toml";
 const CONFIG_FILE_PATH: &str = ".config/tembo/";
 
+// TODO: look into swapping this out for https://crates.io/crates/config
+
 // NOTE: modifying the struct determines what gets persisted in the configuration file
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
@@ -253,6 +255,7 @@ mod tests {
                 created_at: Some(Utc::now()),
                 locations: vec![],
             }],
+            databases: vec![],
         };
         config.instances = vec![instance];
 

--- a/src/cli/database.rs
+++ b/src/cli/database.rs
@@ -1,0 +1,10 @@
+// Objects representing a user created local database
+use chrono::prelude::*;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct Database {
+    pub name: Option<String>,
+    pub created_at: Option<DateTime<Utc>>,
+}

--- a/src/cli/instance.rs
+++ b/src/cli/instance.rs
@@ -2,6 +2,7 @@
 // (a local container that runs with certain attributes and properties)
 
 use crate::cli::config::Config;
+use crate::cli::database::Database;
 use crate::cli::docker::DockerError;
 use crate::cli::extension::Extension;
 use crate::cli::stacks;
@@ -10,6 +11,7 @@ use chrono::prelude::*;
 use clap::ArgMatches;
 use serde::Deserialize;
 use serde::Serialize;
+use simplelog::*;
 use spinners::{Spinner, Spinners};
 use std::cmp::PartialEq;
 use std::error::Error;
@@ -24,6 +26,7 @@ pub struct Instance {
     pub created_at: Option<DateTime<Utc>>,
     pub installed_extensions: Vec<InstalledExtension>,
     pub enabled_extensions: Vec<EnabledExtension>,
+    pub databases: Vec<Database>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -222,7 +225,7 @@ impl Instance {
     pub fn find(args: &ArgMatches, name: &str) -> Result<Instance, InstanceError> {
         let config = Config::new(args, &Config::full_path(args));
 
-        println!("finding config for instance {}", name);
+        info!("finding config for instance {}", name);
 
         for instance in &config.instances {
             let i_name = instance.name.clone().unwrap();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth_client;
 pub mod cloud_account;
 pub mod config;
+pub mod database;
 pub mod docker;
 pub mod extension;
 pub mod instance;

--- a/src/cmd/database.rs
+++ b/src/cmd/database.rs
@@ -1,0 +1,22 @@
+use clap::ArgMatches;
+use simplelog::*;
+use std::error::Error;
+
+pub mod create;
+
+// handles all extension command calls
+pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    // execute the instance subcommands
+    let res = match args.subcommand() {
+        Some(("create", sub_matches)) => create::execute(sub_matches),
+        _ => unreachable!(),
+    };
+
+    if res.is_err() {
+        error!("{}", res.err().unwrap().name);
+
+        std::process::exit(101);
+    }
+
+    Ok(())
+}

--- a/src/cmd/database/create.rs
+++ b/src/cmd/database/create.rs
@@ -1,0 +1,122 @@
+//  database create command
+use crate::cli::config::Config;
+use crate::cli::database::Database;
+use crate::cli::instance::Instance;
+use crate::cli::instance::InstanceError;
+use chrono::Utc;
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use simplelog::*;
+use spinners::{Spinner, Spinners};
+use std::error::Error;
+use std::process::Command as ShellCommand;
+
+// example usage: tembo db create -n my_database -i my_instance
+pub fn make_subcommand() -> Command {
+    Command::new("create")
+        .about("Command used to create databases on instances")
+        .arg(
+            Arg::new("name")
+                .short('n')
+                .long("name")
+                .action(ArgAction::Set)
+                .required(true)
+                .help("The name of the database to create"),
+        )
+        .arg(
+            Arg::new("instance")
+                .short('i')
+                .long("instance")
+                .action(ArgAction::Set)
+                .required(true)
+                .help("The name of the instance to create the database on"),
+        )
+}
+
+pub fn execute(args: &ArgMatches) -> Result<(), Box<InstanceError>> {
+    let config = Config::new(args, &Config::full_path(args));
+    let name_arg = args.try_get_one::<String>("name").unwrap();
+    let instance_arg = args.try_get_one::<String>("instance").unwrap();
+
+    info!(
+        "trying to create database '{}' on instance '{}'",
+        &name_arg.unwrap(),
+        &instance_arg.unwrap()
+    );
+
+    if config.instances.is_empty() {
+        warn!("- No instances have been configured");
+    } else {
+        let _ = match Instance::find(args, instance_arg.unwrap()) {
+            Ok(instance) => create_database(instance, name_arg.unwrap(), args),
+            Err(e) => Err(Box::new(e)),
+        };
+    }
+
+    Ok(())
+}
+
+fn create_database(
+    instance: Instance,
+    name: &str,
+    args: &ArgMatches,
+) -> Result<(), Box<InstanceError>> {
+    instance.start();
+
+    let mut sp = Spinner::new(Spinners::Dots12, "Creating database".into());
+
+    // psql -h localhost -U postgres -c 'create database test;'
+    let mut command = String::from("psql -h localhost -U postgres -p ");
+    command.push_str(&instance.port.clone().unwrap());
+    command.push_str(" -c 'create database ");
+    command.push_str(name);
+    command.push_str(";'");
+
+    let output = ShellCommand::new("sh")
+        .arg("-c")
+        .arg(&command)
+        .output()
+        .expect("failed to execute process");
+
+    sp.stop_with_newline();
+
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    if !stderr.is_empty() {
+        Err(Box::new(InstanceError {
+            name: format!("There was an issue creating the database: {}", stderr),
+        }))
+    } else {
+        info!("database created");
+
+        let _ = persist_config(args, instance);
+
+        Ok(())
+    }
+}
+
+fn persist_config(args: &ArgMatches, target_instance: Instance) -> Result<(), Box<dyn Error>> {
+    let mut config = Config::new(args, &Config::full_path(args));
+    let name_arg = args.try_get_one::<String>("name");
+
+    // TODO: push onto databases vector
+    let database = Database {
+        name: name_arg.clone().unwrap().cloned(),
+        created_at: Some(Utc::now()),
+    };
+
+    for instance in config.instances.iter_mut() {
+        if instance.name.clone().unwrap().to_lowercase()
+            == target_instance.name.clone().unwrap().to_lowercase()
+        {
+            instance.databases.push(database.clone());
+        }
+    }
+
+    match &config.write(&Config::full_path(args)) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            error!("there was an error: {}", e);
+            Err("there was an error writing the config".into())
+        }
+    }
+}

--- a/src/cmd/instance/create.rs
+++ b/src/cmd/instance/create.rs
@@ -96,6 +96,7 @@ fn persist_instance_config(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         version: None,
         installed_extensions: vec![],
         enabled_extensions: vec![],
+        databases: vec![],
     };
 
     let stacks: Stacks = stacks::define_stacks();

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod database;
 pub mod extension;
 pub mod init;
 pub mod instance;

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ fn main() {
     let res = match matches.subcommand() {
         Some(("init", sub_matches)) => cmd::init::execute(sub_matches),
         Some(("instance", sub_matches)) => cmd::instance::execute(sub_matches),
+        Some(("db", sub_matches)) => cmd::database::execute(sub_matches),
         Some(("extension", sub_matches)) => cmd::extension::execute(sub_matches),
         Some(("auth", sub_matches)) => cmd::auth::execute(sub_matches),
         Some(("completions", sub_matches)) => (|| {
@@ -101,6 +102,11 @@ fn create_clap_command() -> Command {
                 .about("Commands used to manage authentication")
                 .subcommand(cmd::auth::login::make_subcommand())
                 .subcommand(cmd::auth::info::make_subcommand()),
+        )
+        .subcommand(
+            Command::new("db")
+                .about("Commands used to manage local and cloud databases")
+                .subcommand(cmd::database::create::make_subcommand()),
         )
         .subcommand(
             Command::new("extension")


### PR DESCRIPTION
This PR introduces the `tembo db create` command. It's needed to create Schemas, which are needed to enable Extensions. Next PR, will nearly be a mirror of this to create Schemas.

```
~/projects/tembo-cli/ [tem-1553-db-create] tembo db create -n testing_command -i test
19:26:55 [INFO] trying to create database 'testing_command' on instance 'test'
19:26:55 [INFO] finding config for instance test
- Tembo instance started on 5432
⢂⠀ Creating database
19:26:55 [INFO] database created

~/projects/tembo-cli/ [tem-1553-db-create] psql -h localhost -U postgres
psql (14.8 (Homebrew), server 15.3)
WARNING: psql major version 14, server major version 15.
         Some psql features might not work.
Type "help" for help.

postgres=# \l
                                    List of databases
       Name       |  Owner   | Encoding |  Collate   |   Ctype    |   Access privileges   
------------------+----------+----------+------------+------------+-----------------------
 postgres         | postgres | UTF8     | en_US.utf8 | en_US.utf8 | 
 template0        | postgres | UTF8     | en_US.utf8 | en_US.utf8 | =c/postgres          +
                  |          |          |            |            | postgres=CTc/postgres
 template1        | postgres | UTF8     | en_US.utf8 | en_US.utf8 | =c/postgres          +
                  |          |          |            |            | postgres=CTc/postgres
 test             | postgres | UTF8     | en_US.utf8 | en_US.utf8 | 
 testing_command  | postgres | UTF8     | en_US.utf8 | en_US.utf8 | 
(10 rows)

postgres=# \q
```