### PR TITLE
[tem-1865] Persists user's org ids in prep for API requests

### DIFF
--- a/src/cli/cloud_account.rs
+++ b/src/cli/cloud_account.rs
@@ -1,11 +1,13 @@
+use chrono::prelude::*;
 use serde::Deserialize;
 use serde::Serialize;
 use std::cmp::PartialEq;
-use toml::value::Datetime;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct CloudAccount {
     pub name: Option<String>,
     pub username: Option<String>,
-    pub created_at: Option<Datetime>,
+    pub clerk_id: Option<String>,
+    pub organizations: Vec<String>,
+    pub created_at: Option<DateTime<Utc>>,
 }

--- a/src/cmd/auth/login.rs
+++ b/src/cmd/auth/login.rs
@@ -10,7 +10,7 @@ pub fn make_subcommand() -> Command {
 }
 
 pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
-    match AuthClient::authenticate() {
+    match AuthClient::authenticate(args) {
         Ok(jwt) => {
             println!("- storing jwt in config file, it will be used in future requests");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ const WINDOWS_ERROR_MSG: &str = "Windows is not supported at this time";
 fn main() {
     CombinedLogger::init(vec![
         TermLogger::new(
-            LevelFilter::Trace,
+            LevelFilter::Info,
             Config::default(),
             TerminalMode::Mixed,
             ColorChoice::Auto,


### PR DESCRIPTION
This PR updates `auth login` to persist more information about a user, their name, and org id(s). Org IDs are needed for API requests.

Small tweak, changed the log level for stdout so Reqwest isn't noisy.

https://www.loom.com/share/dcb7f607a8314039a67b6ab7f9e6753e