### PR TITLE
[tem-1559] instance deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "tembo"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ instances can be started that share a port number.
 
 Each instance runs as a Docker container.
 
+## `tembo instance stop`
+
+The `instance stop` command allows users to stop their running instances. It requires the name as a parameter.
+
+Each instance runs as a Docker container. This command stops the container.
+
+## `tembo instance deploy`
+
+Uses information obtained with `auth login`. Provisions an instance in the cloud, via API, matching the config of a local instance 
+created using `instance create`.
+
 ## `tembo auth login`
 
 The `auth login` command allows users to authenticate as a service user and obtain an API token that can be used on future authenticated requests.

--- a/src/cmd/instance.rs
+++ b/src/cmd/instance.rs
@@ -3,6 +3,7 @@ use simplelog::*;
 use std::error::Error;
 
 pub mod create;
+pub mod deploy;
 pub mod list;
 pub mod start;
 pub mod stop;
@@ -15,6 +16,7 @@ pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
         Some(("list", sub_matches)) => list::execute(sub_matches),
         Some(("start", sub_matches)) => start::execute(sub_matches),
         Some(("stop", sub_matches)) => stop::execute(sub_matches),
+        Some(("deploy", sub_matches)) => deploy::execute(sub_matches),
         _ => unreachable!(),
     };
 

--- a/src/cmd/instance/deploy.rs
+++ b/src/cmd/instance/deploy.rs
@@ -1,0 +1,42 @@
+// instance deploy command
+use crate::cli::config::Config;
+use anyhow::anyhow;
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use simplelog::*;
+use std::error::Error;
+
+// example usage: tembo instance deploy -n my_local_instance
+pub fn make_subcommand() -> Command {
+    Command::new("deploy")
+        .about("Command used to deploy a local instance to the Tembo cloud")
+        .arg(
+            Arg::new("name")
+                .short('n')
+                .long("name")
+                .action(ArgAction::Set)
+                .required(true)
+                .help("The name you want to use for this instance"),
+        )
+}
+
+pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let config = Config::new(args, &Config::full_path(args));
+    let name = args
+        .get_one::<String>("name")
+        .ok_or_else(|| anyhow!("Name is missing."))?;
+
+    if config.instances.is_empty() {
+        info!("No instances have been configured");
+    } else {
+        for instance in &config.instances {
+            if instance.name.clone().unwrap().to_lowercase() == name.to_lowercase() {
+                match instance.deploy(args) {
+                    Ok(_) => info!(" instance deployed"),
+                    Err(e) => warn!(" there was an error deploying the instance: {}", e),
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/cmd/instance/list.rs
+++ b/src/cmd/instance/list.rs
@@ -27,7 +27,7 @@ pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
         }
 
         info!("Start an instance using `tembo instance start -n <name>`");
-        info!("Coming soon: deploy an instance using `tembo instance deploy -n <name>`");
+        info!("Deploy an instance using `tembo instance deploy -n <name>`");
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,8 @@ fn create_clap_command() -> Command {
                 .subcommand(cmd::instance::create::make_subcommand())
                 .subcommand(cmd::instance::list::make_subcommand())
                 .subcommand(cmd::instance::start::make_subcommand())
-                .subcommand(cmd::instance::stop::make_subcommand()),
+                .subcommand(cmd::instance::stop::make_subcommand())
+                .subcommand(cmd::instance::deploy::make_subcommand()),
         )
         .subcommand(
             Command::new("auth")


### PR DESCRIPTION
This PR introduces the `instance deploy` command.

```
 ~/projects/tembo-cli/ [tem-1559-instance-deploy]
cr -- instance create -n my_instance
15:55:12 [INFO] Checking requirements: [Docker]
15:55:12 [INFO] Docker was found and appears running
15:55:12 [INFO] Instance config persisted in config file
15:55:12 [INFO] Instance configuration created, you can start the instance using the command 'tembo start -i <name>'

 ~/projects/tembo-cli/ [tem-1559-instance-deploy]
cr -- instance deploy -n my_instance
15:55:24 [INFO] finding config for instance my_instance
15:55:25 [INFO] provisioning: https://cloud.tembo.io/orgs/org_2TS6bzrPtZTCJR4701S1B4G85Lt/clusters
15:55:25 [INFO]  instance deployed
```