### PR TITLE
adds context list & set subcommands

### DIFF
--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -1,17 +1,17 @@
-// Objects representing a user created local database
-use chrono::prelude::*;
 use serde::Deserialize;
 use serde::Serialize;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Context {
     pub version: String,
-    pub environment: List<Environment>,
+    pub environment: Vec<Environment>,
 }
 
 // Config struct holds to data from the `[config]` section.
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Environment {
-    target: String,
-    org_id: String,
+    pub name: String,
+    pub target: String,
+    pub org_id: Option<String>,
+    pub set: Option<bool>,
 }

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -1,6 +1,28 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+pub const CONTEXT_DEFAULT_TEXT: &str = "version = \"1.0\"
+
+[[environment]]
+name = 'local'
+target = 'docker'
+
+[[environment]]
+name = 'prod'
+target = 'tembo-cloud'
+org_id = 'ORG_ID'
+";
+
+pub fn tembo_home_dir() -> String {
+    let mut tembo_home = home::home_dir().unwrap().as_path().display().to_string();
+    tembo_home.push_str("/.tembo");
+    tembo_home
+}
+
+pub fn tembo_context_file_path() -> String {
+    return tembo_home_dir() + &String::from("/context");
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Context {
     pub version: String,

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -1,0 +1,17 @@
+// Objects representing a user created local database
+use chrono::prelude::*;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct Context {
+    pub version: String,
+    pub environment: List<Environment>,
+}
+
+// Config struct holds to data from the `[config]` section.
+#[derive(Deserialize)]
+pub struct Environment {
+    target: String,
+    org_id: String,
+}

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -6,11 +6,21 @@ pub const CONTEXT_DEFAULT_TEXT: &str = "version = \"1.0\"
 [[environment]]
 name = 'local'
 target = 'docker'
+set = true
 
 [[environment]]
 name = 'prod'
 target = 'tembo-cloud'
 org_id = 'ORG_ID'
+profile = 'prod'
+";
+
+pub const CREDENTIALS_DEFAULT_TEXT: &str = "version = \"1.0\"
+
+[[environment]]
+name = 'prod'
+tembo_access_token = 'ACCESS_TOKEN'
+tembo_host = 'https://api.coredb.io'
 ";
 
 pub fn tembo_home_dir() -> String {
@@ -21,6 +31,10 @@ pub fn tembo_home_dir() -> String {
 
 pub fn tembo_context_file_path() -> String {
     return tembo_home_dir() + &String::from("/context");
+}
+
+pub fn tembo_credentials_file_path() -> String {
+    return tembo_home_dir() + &String::from("/credentials");
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -35,5 +49,6 @@ pub struct Environment {
     pub name: String,
     pub target: String,
     pub org_id: Option<String>,
+    pub profile: Option<String>,
     pub set: Option<bool>,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth_client;
 pub mod cloud_account;
 pub mod config;
+pub mod context;
 pub mod database;
 pub mod docker;
 pub mod extension;

--- a/src/cmd/context.rs
+++ b/src/cmd/context.rs
@@ -1,19 +1,22 @@
+use std::error::Error;
+
 use clap::ArgMatches;
 use serde::{Deserialize, Serialize};
 use simplelog::*;
-use toml::value::Array;
-use std::error::Error;
 
 pub mod list;
+pub mod set;
 
 pub const CONTEXT_DEFAULT_TEXT: &str = "version = \"1.0\"
 
-[local]
+[[environment]]
+name = 'local'
 target = 'docker'
 
-[prod]
+[[environment]]
+name = 'prod'
 target = 'tembo-cloud'
-org_id = 'ORG_ID_GOES_HERE'
+org_id = 'ORG_ID'
 ";
 
 pub fn tembo_home_dir() -> String {
@@ -25,15 +28,16 @@ pub fn tembo_home_dir() -> String {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Context {
     pub version: String,
-    pub local: Environment,
-    pub prod: Environment,
+    pub environment: Vec<Environment>,
 }
 
 // Config struct holds to data from the `[config]` section.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Environment {
+    name: String,
     target: String,
     org_id: Option<String>,
+    set: Option<bool>,
 }
 
 pub fn tembo_context_file_path() -> String {
@@ -45,6 +49,7 @@ pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
     // execute the context subcommands
     let res = match args.subcommand() {
         Some(("list", sub_matches)) => list::execute(sub_matches),
+        Some(("set", sub_matches)) => set::execute(sub_matches),
 
         _ => unreachable!(),
     };

--- a/src/cmd/context.rs
+++ b/src/cmd/context.rs
@@ -6,28 +6,6 @@ use simplelog::*;
 pub mod list;
 pub mod set;
 
-pub const CONTEXT_DEFAULT_TEXT: &str = "version = \"1.0\"
-
-[[environment]]
-name = 'local'
-target = 'docker'
-
-[[environment]]
-name = 'prod'
-target = 'tembo-cloud'
-org_id = 'ORG_ID'
-";
-
-pub fn tembo_home_dir() -> String {
-    let mut tembo_home = home::home_dir().unwrap().as_path().display().to_string();
-    tembo_home.push_str("/.tembo");
-    tembo_home
-}
-
-pub fn tembo_context_file_path() -> String {
-    return tembo_home_dir() + &String::from("/context");
-}
-
 // handles all context command calls
 pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
     // execute the context subcommands

--- a/src/cmd/context.rs
+++ b/src/cmd/context.rs
@@ -1,0 +1,60 @@
+use clap::ArgMatches;
+use serde::{Deserialize, Serialize};
+use simplelog::*;
+use toml::value::Array;
+use std::error::Error;
+
+pub mod list;
+
+pub const CONTEXT_DEFAULT_TEXT: &str = "version = \"1.0\"
+
+[local]
+target = 'docker'
+
+[prod]
+target = 'tembo-cloud'
+org_id = 'ORG_ID_GOES_HERE'
+";
+
+pub fn tembo_home_dir() -> String {
+    let mut tembo_home = home::home_dir().unwrap().as_path().display().to_string();
+    tembo_home.push_str("/.tembo");
+    tembo_home
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct Context {
+    pub version: String,
+    pub local: Environment,
+    pub prod: Environment,
+}
+
+// Config struct holds to data from the `[config]` section.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct Environment {
+    target: String,
+    org_id: Option<String>,
+}
+
+pub fn tembo_context_file_path() -> String {
+    return tembo_home_dir() + &String::from("/context");
+}
+
+// handles all context command calls
+pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    // execute the context subcommands
+    let res = match args.subcommand() {
+        Some(("list", sub_matches)) => list::execute(sub_matches),
+
+        _ => unreachable!(),
+    };
+
+    if res.is_err() {
+        error!("{}", res.err().unwrap());
+
+        // TODO: adding logging, log error
+        std::process::exit(101);
+    }
+
+    Ok(())
+}

--- a/src/cmd/context.rs
+++ b/src/cmd/context.rs
@@ -1,7 +1,6 @@
 use std::error::Error;
 
 use clap::ArgMatches;
-use serde::{Deserialize, Serialize};
 use simplelog::*;
 
 pub mod list;
@@ -23,21 +22,6 @@ pub fn tembo_home_dir() -> String {
     let mut tembo_home = home::home_dir().unwrap().as_path().display().to_string();
     tembo_home.push_str("/.tembo");
     tembo_home
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct Context {
-    pub version: String,
-    pub environment: Vec<Environment>,
-}
-
-// Config struct holds to data from the `[config]` section.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct Environment {
-    name: String,
-    target: String,
-    org_id: Option<String>,
-    set: Option<bool>,
 }
 
 pub fn tembo_context_file_path() -> String {

--- a/src/cmd/context/list.rs
+++ b/src/cmd/context/list.rs
@@ -25,21 +25,25 @@ pub fn execute(_args: &ArgMatches) -> Result<(), Box<dyn Error>> {
     };
 
     // TODO: Improve formatting
-    println!("Name           Target         Org ID         Set");
-    println!("-------------- -------------- -------------- --------------");
+    println!("Name           Target         Org ID         Profile         Set");
+    println!("-------------- -------------- -------------- -------------- --------------");
 
     for e in data.environment {
         let mut org_id = String::new();
+        let mut profile = String::new();
         let mut set = false;
         if !e.org_id.is_none() {
             org_id = e.org_id.unwrap();
+        }
+        if !e.profile.is_none() {
+            profile = e.profile.unwrap();
         }
         if !e.set.is_none() {
             set = e.set.unwrap();
         }
         println!(
-            "{}           {}        {:?}           {:?}",
-            e.name, e.target, org_id, set
+            "{}           {}        {:?}         {:?}          {:?}",
+            e.name, e.target, org_id, profile, set
         );
     }
 

--- a/src/cmd/context/list.rs
+++ b/src/cmd/context/list.rs
@@ -1,0 +1,34 @@
+// context list command
+use crate::{cli::config::Config, cmd::{auth::info, context::{tembo_context_file_path, Context}}};
+use clap::{ArgMatches, Command};
+use simplelog::*;
+use std::{error::Error, fs};
+
+// example usage: tembo context create -t oltp -n my_app_db -p 5432
+pub fn make_subcommand() -> Command {
+    Command::new("list").about("Command used to list local contexts")
+}
+
+pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let filename = tembo_context_file_path();
+
+    let contents = match fs::read_to_string(&filename) {
+        Ok(c) => c,
+        Err(e) => {
+            panic!("Couldn't read config file {}: {}", filename, e);
+        }
+    };
+
+    let data: Context = match toml::from_str(&contents) {
+        Ok(d) => d,
+        Err(e) => {
+            panic!("Unable to load data from `{}`", e);
+        }
+    };
+
+    info!("{}", contents);
+    
+    info!("{}", data.version);
+    
+    Ok(())
+}

--- a/src/cmd/context/list.rs
+++ b/src/cmd/context/list.rs
@@ -1,7 +1,7 @@
 use clap::{ArgMatches, Command};
 use std::{error::Error, fs};
 
-use crate::{cli::context::Context, cmd::context::tembo_context_file_path};
+use crate::cli::context::{tembo_context_file_path, Context};
 
 pub fn make_subcommand() -> Command {
     Command::new("list").about("Command used to list context")

--- a/src/cmd/context/list.rs
+++ b/src/cmd/context/list.rs
@@ -1,7 +1,7 @@
 use clap::{ArgMatches, Command};
 use std::{error::Error, fs};
 
-use crate::cmd::context::{tembo_context_file_path, Context};
+use crate::{cli::context::Context, cmd::context::tembo_context_file_path};
 
 pub fn make_subcommand() -> Command {
     Command::new("list").about("Command used to list context")

--- a/src/cmd/context/list.rs
+++ b/src/cmd/context/list.rs
@@ -1,15 +1,15 @@
 // context list command
-use crate::{cli::config::Config, cmd::{auth::info, context::{tembo_context_file_path, Context}}};
 use clap::{ArgMatches, Command};
-use simplelog::*;
 use std::{error::Error, fs};
+
+use crate::cmd::context::{tembo_context_file_path, Context};
 
 // example usage: tembo context create -t oltp -n my_app_db -p 5432
 pub fn make_subcommand() -> Command {
     Command::new("list").about("Command used to list local contexts")
 }
 
-pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+pub fn execute(_args: &ArgMatches) -> Result<(), Box<dyn Error>> {
     let filename = tembo_context_file_path();
 
     let contents = match fs::read_to_string(&filename) {
@@ -26,9 +26,23 @@ pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
         }
     };
 
-    info!("{}", contents);
-    
-    info!("{}", data.version);
-    
+    println!("Name           Target         Org ID         Set");
+    println!("-------------- -------------- -------------- --------------");
+
+    for e in data.environment {
+        let mut org_id = String::new();
+        let mut set = false;
+        if !e.org_id.is_none() {
+            org_id = e.org_id.unwrap();
+        }
+        if !e.set.is_none() {
+            set = e.set.unwrap();
+        }
+        println!(
+            "{}           {}        {:?}           {:?}",
+            e.name, e.target, org_id, set
+        );
+    }
+
     Ok(())
 }

--- a/src/cmd/context/list.rs
+++ b/src/cmd/context/list.rs
@@ -1,12 +1,10 @@
-// context list command
 use clap::{ArgMatches, Command};
 use std::{error::Error, fs};
 
 use crate::cmd::context::{tembo_context_file_path, Context};
 
-// example usage: tembo context create -t oltp -n my_app_db -p 5432
 pub fn make_subcommand() -> Command {
-    Command::new("list").about("Command used to list local contexts")
+    Command::new("list").about("Command used to list context")
 }
 
 pub fn execute(_args: &ArgMatches) -> Result<(), Box<dyn Error>> {
@@ -15,17 +13,18 @@ pub fn execute(_args: &ArgMatches) -> Result<(), Box<dyn Error>> {
     let contents = match fs::read_to_string(&filename) {
         Ok(c) => c,
         Err(e) => {
-            panic!("Couldn't read config file {}: {}", filename, e);
+            panic!("Couldn't read context file {}: {}", filename, e);
         }
     };
 
     let data: Context = match toml::from_str(&contents) {
         Ok(d) => d,
         Err(e) => {
-            panic!("Unable to load data from `{}`", e);
+            panic!("Unable to load data. Error: `{}`", e);
         }
     };
 
+    // TODO: Improve formatting
     println!("Name           Target         Org ID         Set");
     println!("-------------- -------------- -------------- --------------");
 

--- a/src/cmd/context/set.rs
+++ b/src/cmd/context/set.rs
@@ -1,4 +1,3 @@
-// context set command
 use crate::cmd::context::{tembo_context_file_path, Context};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use std::io::Write;
@@ -34,7 +33,7 @@ pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
     let mut data: Context = match toml::from_str(&contents) {
         Ok(d) => d,
         Err(e) => {
-            panic!("Unable to load data from `{}`", e);
+            panic!("Unable to load data. Error: `{}`", e);
         }
     };
 

--- a/src/cmd/context/set.rs
+++ b/src/cmd/context/set.rs
@@ -1,0 +1,68 @@
+// context set command
+use crate::cmd::context::{tembo_context_file_path, Context};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use std::io::Write;
+use std::{
+    error::Error,
+    fs::{self, File},
+};
+use toml::to_string;
+
+pub fn make_subcommand() -> Command {
+    Command::new("set")
+        .arg(
+            Arg::new("name")
+                .short('n')
+                .long("name")
+                .action(ArgAction::Set)
+                .required(true)
+                .help("The name of the context to set"),
+        )
+        .about("Command used to set context")
+}
+
+pub fn execute(args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+    let filename = tembo_context_file_path();
+
+    let contents = match fs::read_to_string(&filename) {
+        Ok(c) => c,
+        Err(e) => {
+            panic!("Couldn't read context file {}: {}", filename, e);
+        }
+    };
+
+    let mut data: Context = match toml::from_str(&contents) {
+        Ok(d) => d,
+        Err(e) => {
+            panic!("Unable to load data from `{}`", e);
+        }
+    };
+
+    let name = args.get_one::<String>("name").unwrap();
+
+    for e in data.environment.iter_mut() {
+        if &e.name == name {
+            e.set = Some(true)
+        } else {
+            e.set = None
+        }
+    }
+
+    if let Err(e) = write_config_to_file(&data, &tembo_context_file_path()) {
+        eprintln!("Error: {}", e);
+    }
+
+    Ok(())
+}
+
+fn write_config_to_file(
+    config: &Context,
+    file_path: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let toml_string = to_string(config)?;
+    let mut file = File::create(file_path)?;
+
+    file.write_all(toml_string.as_bytes())?;
+
+    Ok(())
+}

--- a/src/cmd/context/set.rs
+++ b/src/cmd/context/set.rs
@@ -1,4 +1,5 @@
-use crate::cmd::context::{tembo_context_file_path, Context};
+use crate::cli::context::Context;
+use crate::cmd::context::tembo_context_file_path;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use std::io::Write;
 use std::{

--- a/src/cmd/context/set.rs
+++ b/src/cmd/context/set.rs
@@ -1,5 +1,4 @@
-use crate::cli::context::Context;
-use crate::cmd::context::tembo_context_file_path;
+use crate::cli::context::{tembo_context_file_path, Context};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use std::io::Write;
 use std::{

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -5,7 +5,7 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
 
-use super::context::{CONTEXT_DEFAULT_TEXT, tembo_home_dir, tembo_context_file_path};
+use super::context::{tembo_context_file_path, tembo_home_dir, CONTEXT_DEFAULT_TEXT};
 
 // Create init subcommand arguments
 pub fn make_subcommand() -> Command {

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -5,26 +5,12 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
 
-const CONTEXT_DEFAULT_TEXT: &str = "version = \"1.0\"
-
-[local]
-target: docker
-
-[prod]
-target: tembo-cloud
-org_id: ORG_ID_GOES_HERE
-";
-
-fn tembo_home_dir() -> String {
-    let mut tembo_home = home::home_dir().unwrap().as_path().display().to_string();
-    tembo_home.push_str("/.tembo");
-    tembo_home
-}
+use super::context::{CONTEXT_DEFAULT_TEXT, tembo_home_dir, tembo_context_file_path};
 
 // Create init subcommand arguments
 pub fn make_subcommand() -> Command {
     Command::new("init")
-        .about("Initializes a local environment; generates configuration and pulls Docker image")
+        .about("Initializes a local environment; creates needed context & config files/directories")
 }
 
 pub fn execute(_args: &ArgMatches) -> Result<(), Box<dyn Error>> {
@@ -35,7 +21,7 @@ pub fn execute(_args: &ArgMatches) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    let context_file_path = tembo_home_dir() + &String::from("/context");
+    let context_file_path = tembo_context_file_path();
     match create_file(
         "context".to_string(),
         context_file_path,

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -5,7 +5,7 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
 
-use super::context::{tembo_context_file_path, tembo_home_dir, CONTEXT_DEFAULT_TEXT};
+use crate::cli::context::{tembo_context_file_path, tembo_home_dir, CONTEXT_DEFAULT_TEXT};
 
 // Create init subcommand arguments
 pub fn make_subcommand() -> Command {

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -5,7 +5,10 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
 
-use crate::cli::context::{tembo_context_file_path, tembo_home_dir, CONTEXT_DEFAULT_TEXT};
+use crate::cli::context::{
+    tembo_context_file_path, tembo_credentials_file_path, tembo_home_dir, CONTEXT_DEFAULT_TEXT,
+    CREDENTIALS_DEFAULT_TEXT,
+};
 
 // Create init subcommand arguments
 pub fn make_subcommand() -> Command {
@@ -21,11 +24,21 @@ pub fn execute(_args: &ArgMatches) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    let context_file_path = tembo_context_file_path();
     match create_file(
         "context".to_string(),
-        context_file_path,
+        tembo_context_file_path(),
         CONTEXT_DEFAULT_TEXT.to_string(),
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            return Err(e);
+        }
+    }
+
+    match create_file(
+        "credentials".to_string(),
+        tembo_credentials_file_path(),
+        CREDENTIALS_DEFAULT_TEXT.to_string(),
     ) {
         Ok(t) => t,
         Err(e) => {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -3,4 +3,5 @@ pub mod database;
 pub mod extension;
 pub mod init;
 pub mod instance;
+pub mod context;
 pub mod schema;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,7 +1,7 @@
 pub mod auth;
+pub mod context;
 pub mod database;
 pub mod extension;
 pub mod init;
 pub mod instance;
-pub mod context;
 pub mod schema;

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,8 @@ fn create_clap_command() -> Command {
         .subcommand(
             Command::new("context")
                 .about("Commands used to list/get/set context")
-                .subcommand(cmd::instance::list::make_subcommand())
+                .subcommand(cmd::context::list::make_subcommand())
+                .subcommand(cmd::context::set::make_subcommand()),
         )
         .subcommand(
             Command::new("auth")

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ fn main() {
 
     let res = match matches.subcommand() {
         Some(("init", sub_matches)) => cmd::init::execute(sub_matches),
+        Some(("context", sub_matches)) => cmd::context::execute(sub_matches),
         Some(("instance", sub_matches)) => cmd::instance::execute(sub_matches),
         Some(("db", sub_matches)) => cmd::database::execute(sub_matches),
         Some(("schema", sub_matches)) => cmd::schema::execute(sub_matches),
@@ -97,6 +98,11 @@ fn create_clap_command() -> Command {
                 .subcommand(cmd::instance::list::make_subcommand())
                 .subcommand(cmd::instance::start::make_subcommand())
                 .subcommand(cmd::instance::stop::make_subcommand()),
+        )
+        .subcommand(
+            Command::new("context")
+                .about("Commands used to list/get/set context")
+                .subcommand(cmd::instance::list::make_subcommand())
         )
         .subcommand(
             Command::new("auth")


### PR DESCRIPTION
* Adds the following subcommands: 
  * `tembo context list` - Returns the list of contexts from `~/.tembo/context` file
  * `tembo context set -n prod` - Sets context to the name provided

**TODO:**
* Better error handling 
* Add tests
* Might refactor the commands above to make them simpler 